### PR TITLE
Add support for all CLRS tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Available dataset names (which can be used with `create_dataset()`):
 'family_relationships',
 'propositional_logic',
 'syllogism'
+'clrs'
 ```
 
 ### Task Overview
@@ -82,6 +83,7 @@ Available dataset names (which can be used with `create_dataset()`):
 - `NumberSortingDataset`: Sort lists of numbers in ascending or descending order
 - `LetterJumbleDataset`: Unscramble words that have had their letters randomly jumbled
 - `WordReversalDataset`: Reverse word order in text spans
+- `ClrsDataset`: Any algorithmic task from [CLRS](https://github.com/google-deepmind/clrs)
 
 #### Cognition Tasks
 
@@ -365,6 +367,120 @@ Navigate from 'J' (start) to '_' (goal):
 Legend: '<' = Wall, 'w' = Path
 
 {'question': "Navigate from 'J' (start) to '_' (goal):\n\n<<<<<\n<<J<<\n<www<\n<<w_<\n<<<<<\nLegend: '<' = Wall, 'w' = Path\n", 'answer': '3', 'metadata': {'grid_size': 5, 'grid': ['<<<<<', '<<J<<', '<www<', '<<w_<', '<<<<<'], 'shortest_path_length': 3, 'start': 'J', 'goal': '_', 'wall': '<', 'path': 'w'}}
+```
+
+#### CLRS
+
+Generates a task from [CLRS](https://github.com/google-deepmind/clrs). The length config parameter is the number of nodes (e.g. dijkstra) or length of the array (e.g. quicksort).
+Available tasks:
+
+- activity_selector
+- articulation_points
+- bellman_ford
+- bfs
+- binary_search
+- bridges
+- bubble_sort
+- dag_shortest_paths
+- dfs
+- dijkstra
+- find_maximum_subarray_kadane
+- floyd_warshall
+- graham_scan
+- heapsort
+- insertion_sort
+- jarvis_march
+- kmp_matcher
+- lcs_length
+- matrix_chain_order
+- minimum
+- mst_kruskal
+- mst_prim
+- naive_string_matcher
+- optimal_bst
+- quickselect
+- quicksort
+- segments_intersect
+- strongly_connected_components
+- task_scheduling
+- topological_sort
+
+```python
+import pprint
+from reasoning_gym.algorithmic import ClrsDataset, ClrsConfig
+
+for subtask in ["bfs", "dijkstra", "kmp_matcher", "quicksort", "topological_sort"]:
+    config = ClrsConfig(
+        subtask=subtask,
+        min_length=4,
+        max_length=4,
+        seed=123,
+        size=1,
+    )
+    ds = ClrsDataset(config=config)
+
+    print()
+    for i, example in enumerate(ds):
+        pprint.pprint(example)
+```
+
+Example data:
+
+```
+{'answer': '[0 1 2 3]',
+ 'metadata': {'arrays': {'A': [[1, 0, 0, 0],
+                               [0, 0, 0, 0],
+                               [0, 0, 0, 0],
+                               [0, 0, 0, 1]],
+                         's': 3},
+              'length': 4},
+ 'question': 'bfs:\n'
+             's: 3, A: [[1 0 0 0], [0 0 0 0], [0 0 0 0], [0 0 0 1]]\n'
+             'pi:\n'}
+
+{'answer': '[0 1 2 3]',
+ 'metadata': {'arrays': {'A': [[0.1852113162955031, 0.0, 0.0, 0.0],
+                               [0.0, 0.0, 0.0, 0.0],
+                               [0.0, 0.0, 0.0, 0.0],
+                               [0.0, 0.0, 0.0, 0.4348525119895227]],
+                         'pi': '',
+                         's': 2},
+              'length': 4},
+ 'question': 'dijkstra:\n'
+             's: 2, A: [[0.1852113162955031 0.0 0.0 0.0], [0.0 0.0 0.0 0.0], '
+             '[0.0 0.0 0.0 0.0], [0.0 0.0 0.0 0.4348525119895227]]\n'
+             'pi:\n'}
+
+{'answer': '0',
+ 'metadata': {'arrays': {'key': [2, 2, 2, 2],
+                         'match': '',
+                         'string': [0, 0, 0, 1]},
+              'length': 4},
+ 'question': 'kmp_matcher:\nstring: [0 0 0 1], key: [2 2 2 2]\nmatch:\n'}
+
+{'answer': '[0.2268514535642031 0.28613933495037946 0.5513147690828912 '
+           '0.6964691855978616]',
+ 'metadata': {'arrays': {'key': [0.6964691855978616,
+                                 0.28613933495037946,
+                                 0.2268514535642031,
+                                 0.5513147690828912],
+                         'pred': ''},
+              'length': 4},
+ 'question': 'quicksort:\n'
+             'key: [0.6964691855978616 0.28613933495037946 0.2268514535642031 '
+             '0.5513147690828912]\n'
+             'pred:\n'}
+
+{'answer': '[2 0 3 3], 1',
+ 'metadata': {'arrays': {'A': [[0, 0, 1, 1],
+                               [0, 0, 0, 1],
+                               [0, 0, 0, 1],
+                               [0, 0, 0, 0]],
+                         'topo_head': ''},
+              'length': 4},
+ 'question': 'topological_sort:\n'
+             'A: [[0 0 1 1], [0 0 0 1], [0 0 0 1], [0 0 0 0]]\n'
+             'topo, topo_head:\n'}
 ```
 
 ### Future Generator Ideas

--- a/reasoning_gym/algorithmic/__init__.py
+++ b/reasoning_gym/algorithmic/__init__.py
@@ -13,6 +13,7 @@ from .letter_jumble import LetterJumbleConfig, LetterJumbleDataset
 from .number_filtering import NumberFilteringConfig, NumberFilteringDataset
 from .number_sorting import NumberSortingConfig, NumberSortingDataset
 from .word_reversal import WordReversalConfig, WordReversalDataset
+from .clrs_task import ClrsConfig, ClrsDataset
 
 __all__ = [
     "BaseConversionConfig",
@@ -29,4 +30,6 @@ __all__ = [
     "NumberSortingDataset",
     "WordReversalConfig",
     "WordReversalDataset",
+    "ClrsConfig",
+    "ClrsDataset",
 ]

--- a/reasoning_gym/algorithmic/clrs_task.py
+++ b/reasoning_gym/algorithmic/clrs_task.py
@@ -1,0 +1,399 @@
+from dataclasses import dataclass
+from typing import Optional, List, Dict, Any
+import random
+import re
+
+from clrs._src import samplers as clrs_samplers
+from clrs._src.clrs_text import clrs_utils
+
+from ..factory import ProceduralDataset, register_dataset
+
+
+@dataclass
+class ClrsConfig:
+    """
+    Configuration for a CLRS subtask dataset.
+
+    - subtask: Name of the CLRS algorithm/subtask, e.g. "heapsort", "bfs".
+    - min_length: Minimum number of length.
+    - max_length: Maximum number of length.
+    - seed: Optional random seed for reproducibility.
+    - size: Number of examples in the dataset.
+    - num_decimals_in_float: Truncation for float decimals in the sampler
+      (see clrs samplers docs). None = no truncation.
+
+    Supported subtasks:
+        'activity_selector'
+        'articulation_points'
+        'bellman_ford'
+        'bfs'
+        'binary_search'
+        'bridges'
+        'bubble_sort'
+        'dag_shortest_paths'
+        'dfs'
+        'dijkstra'
+        'find_maximum_subarray_kadane'
+        'floyd_warshall'
+        'graham_scan'
+        'heapsort'
+        'insertion_sort'
+        'jarvis_march'
+        'kmp_matcher'
+        'lcs_length'
+        'matrix_chain_order'
+        'minimum'
+        'mst_kruskal'
+        'mst_prim'
+        'naive_string_matcher'
+        'optimal_bst'
+        'quickselect'
+        'quicksort'
+        'segments_intersect'
+        'strongly_connected_components'
+        'task_scheduling'
+        'topological_sort'
+    """
+
+    subtask: str
+    min_length: int
+    max_length: int
+    seed: Optional[int] = None
+    size: int = 50
+    num_decimals_in_float: Optional[int] = None
+
+    def validate(self):
+        assert self.min_length > 0, "min_length must be positive"
+        assert self.max_length >= self.min_length, "max_length must be >= min_length"
+        assert len(self.subtask) > 0, "subtask must be non-empty"
+
+
+class ClrsDataset(ProceduralDataset):
+    """
+    Dataset that generates CLRS examples for a single subtask, each with a
+    randomly chosen length in [min_length, max_length].
+    """
+
+    def __init__(self, config: ClrsConfig):
+        config.validate()
+        super().__init__(seed=config.seed, size=config.size, config=config)
+        self.config = config
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        """
+        Returns:
+          A dict with keys:
+            - "question": The text prompt from CLRS (the 'prompt' field).
+            - "answer": The last reference from CLRS (string).
+            - "metadata": Additional info, including:
+                * "length" (the length used in this sample)
+                * "arrays" (any arrays we parsed from the prompt, e.g. 'key')
+        """
+        rng = random.Random(self.seed + idx)
+
+        # Pick a random length in [min_length, max_length]
+        length = rng.randint(self.config.min_length, self.config.max_length)
+
+        # Build a sampler for this subtask, with the chosen length
+        sampler, _ = clrs_samplers.build_sampler(
+            name=self.config.subtask,
+            seed=self.seed + idx,
+            num_samples=-1,  # data generated on the fly
+            length=length,
+            track_max_steps=False,
+            truncate_decimals=self.config.num_decimals_in_float,
+        )
+
+        # Get a single sample from the sampler
+        #   (batch_size=1 => we get exactly one example)
+        sample = sampler.next(batch_size=1)
+        # Format the result using clrs_text utilities
+        question_text, answer_text = clrs_utils.format_clrs_example(
+            algo=self.config.subtask,
+            sample=sample,
+            use_hints=False,
+        )
+
+        return {
+            "question": question_text,
+            "answer": answer_text.strip(),
+            "metadata": {
+                "length": length,
+                "arrays": self._parse_question(self.config.subtask, question_text),
+            },
+        }
+
+    def _parse_question(self, subtask: str, question: str) -> Dict[str, Any]:
+        """
+        Parse the question text for known lines, arrays, or scalars
+        that differ by subtask. We'll demonstrate a few tasks
+        as examples. You can add more as needed.
+        """
+        if subtask == "activity_selector":
+            return self._parse_activity_selector(question)
+        elif subtask == "bfs":
+            return self._parse_bfs(question)
+        elif subtask == "bellman_ford":
+            return self._parse_bellman_ford(question)
+        elif subtask == "binary_search":
+            return self._parse_binary_search(question)
+        elif subtask == "bubble_sort":
+            return self._parse_bubble_sort(question)
+        else:
+            return self._parse_generic_arrays(question)
+
+    def _parse_activity_selector(self, question: str) -> Dict[str, Any]:
+        """
+        Example question:
+          "activity_selector:\n
+           s: [0.6964691855978616 0.28613933495037946 ...], f: [0.7194689697 ...]\n
+           selected:\n"
+        We want to parse the line with "s: [...]" and "f: [...]" as 1D arrays.
+        """
+        arrays_dict: Dict[str, Any] = {"s": [], "f": []}
+
+        lines = question.split("\n")
+        for line in lines:
+            line = line.strip()
+            if line.startswith("s: ["):
+                [s, f] = line.split("f:")
+                arrays_dict["s"] = self._parse_1d_float_array(s)
+                arrays_dict["f"] = self._parse_1d_float_array(f)
+        return arrays_dict
+
+    def _parse_bfs(self, question: str) -> Dict[str, Any]:
+        """
+        Example question:
+          "bfs:\n
+           s: 3, A: [[1 0 0 0], [0 0 0 0], ...]\n
+           pi:\n"
+        We'll parse 's' as an integer, 'A' as a 2D adjacency matrix.
+        """
+        arrays_dict: Dict[str, Any] = {"s": None, "A": []}
+
+        # s: 3, A: [[1 0 0 0], [0 0 0 0], [0 0 0 0], [0 0 0 1]]
+        # We'll find 's:' as an integer, 'A:' as 2D
+        lines = question.split("\n")
+        for line in lines:
+            line = line.strip()
+            if line.startswith("s:"):
+                # could be "s: 3, A: [[1 0 0 ...]]"
+                # We'll separate by comma
+                parts = re.split(r", (?=[a-zA-Z])", line)
+                # The first part should be "s: 3"
+                s_part = parts[0].replace("s:", "").strip()
+                arrays_dict["s"] = int(s_part)
+
+                # The second part might have "A: [[...]]"
+                if len(parts) > 1 and "A:" in parts[1]:
+                    a_str = parts[1].split("A:")[1].strip()
+                    arrays_dict["A"] = self._parse_2d_array(a_str)
+
+            elif line.startswith("A: [["):
+                # e.g. A: [[1 0 0 0], [0 0 0 0], ...]
+                arrays_dict["A"] = self._parse_2d_array(line.replace("A:", "").strip())
+
+        return arrays_dict
+
+    def _parse_bellman_ford(self, question: str) -> Dict[str, Any]:
+        """
+        e.g. "bellman_ford:\n
+              s: 2, A: [[0.1852 0.0 ...], [0.0 0.0 ...], ...]\n
+              pi:\n"
+        """
+        arrays_dict = {"s": None, "A": []}
+
+        lines = question.split("\n")
+        for line in lines:
+            line = line.strip()
+            if line.startswith("s:"):
+                # "s: 2, A: [[0.1852 0.0 ...]]"
+                parts = re.split(r", (?=[a-zA-Z])", line)
+                s_part = parts[0].replace("s:", "").strip()
+                arrays_dict["s"] = int(s_part)
+                # second part might be " A: [[...]]"
+                if len(parts) > 1 and "A:" in parts[1]:
+                    a_str = parts[1].split("A:")[1].strip()
+                    arrays_dict["A"] = self._parse_2d_array(a_str)
+            elif line.startswith("A: [["):
+                arrays_dict["A"] = self._parse_2d_array(line.replace("A:", "").strip())
+        return arrays_dict
+
+    def _parse_binary_search(self, question: str) -> Dict[str, Any]:
+        """
+        e.g. "binary_search:\n
+              key: [0.2268 0.2861 0.5513 0.6964], target: 0.7194\n
+              return:\n"
+        We'll parse "key" as a 1D array, "target" as float
+        """
+        arrays_dict = {"key": [], "target": None}
+        lines = question.split("\n")
+        for line in lines:
+            line = line.strip()
+            if line.startswith("key: ["):
+                # might be "key: [0.2268 0.2861 ...], target: 0.7194"
+                # separate by comma
+                parts = line.split(",")
+                # first part => "key: [0.2268 0.2861 ...]"
+                arrays_dict["key"] = self._parse_1d_float_array(parts[0])
+
+                # second part => " target: 0.7194"
+                if len(parts) > 1 and "target:" in parts[1]:
+                    t_str = parts[1].replace("target:", "").strip()
+                    arrays_dict["target"] = int(t_str) if "." not in t_str else float(t_str)
+            elif line.startswith("target:"):
+                # If it's on its own line
+                t_str = line.replace("target:", "").strip()
+                arrays_dict["target"] = int(t_str) if "." not in t_str else float(t_str)
+        return arrays_dict
+
+    def _parse_bubble_sort(self, question: str) -> Dict[str, Any]:
+        """
+        e.g. "bubble_sort:\n
+              key: [0.6964 0.2861 0.2268 0.5513]\n
+              pred:\n"
+        We'll parse 'key' as a 1D float array.
+        """
+        arrays_dict = {"key": []}
+        lines = question.split("\n")
+        for line in lines:
+            line = line.strip()
+            if line.startswith("key: ["):
+                arrays_dict["key"] = self._parse_1d_float_array(line)
+        return arrays_dict
+
+    def _parse_generic_arrays(self, question: str) -> Dict[str, Any]:
+        """
+        Fallback parser that tries to parse lines matching:
+          X: [1 2 3]
+          X: [[1 0 0], [0 1 0], ...]
+          X: 42
+        and stores them in arrays[X].
+        This won't perfectly handle all tasks, but it's a start.
+        """
+        arrays_dict: Dict[str, Any] = {}
+
+        lines = question.split("\n")
+        # skip the first line "<subtask>:" e.g. "bfs:"
+        # because it's just the subtask name
+        for line in lines[1:]:
+            line = line.strip()
+            if not line:
+                continue
+            # Example forms:
+            # "s: 3, A: [[1 0 0 0], [0 0 0 0], ...]"
+            # "A: [[1 0], [0 1]]"
+            # "key: [0.1 0.2 0.3]"
+            # "x: 2"
+            if ":" not in line:
+                continue
+
+            # We handle multiple fields on one line if separated by commas and a letter
+            parts = [p.strip() for p in re.split(r", (?=[a-zA-Z])", line)]
+            for part in parts:
+                if ":" not in part:
+                    continue
+                field, raw_val = part.split(":", 1)
+                field = field.strip()
+                raw_val = raw_val.strip()
+                # Decide if it's 1D array, 2D array, or single value
+                if raw_val.startswith("[["):
+                    # 2D array
+                    arr = self._parse_2d_array(raw_val)
+                    arrays_dict[field] = arr
+                elif raw_val.startswith("["):
+                    # 1D array
+                    arr = self._parse_1d_array(raw_val)
+                    arrays_dict[field] = arr
+                else:
+                    # possibly a single integer or float
+                    # Try parse int first, fallback float
+                    try:
+                        val = int(raw_val)
+                        arrays_dict[field] = val
+                    except ValueError:
+                        try:
+                            arrays_dict[field] = int(raw_val) if "." not in raw_val else float(raw_val)
+                        except ValueError:
+                            # can't parse => store raw string
+                            arrays_dict[field] = raw_val
+        return arrays_dict
+
+    # ----------------------------------------------------------------
+    # Basic string -> array parsing utilities
+    # ----------------------------------------------------------------
+    def _parse_1d_float_array(self, line: str) -> List[float]:
+        """
+        Given a string like
+          "key: [0.6964 0.2861 0.2268 0.5513]"
+        or
+          "[0.6964 0.2861 0.2268 0.5513]"
+        returns [0.6964, 0.2861, ...]
+        """
+        # remove "key:" if present
+        if ":" in line:
+            line = line.split(":", 1)[1].strip()
+        # remove brackets [...]
+        line = line.strip()
+        # e.g. "[0.6964 0.2861 0.2268 0.5513]"
+        if line.startswith("["):
+            line = line[1:]
+        if line.endswith("]"):
+            line = line[:-1]
+        line = line.strip()
+        if not line:
+            return []
+        # split by whitespace
+        parts = line.split()
+        floats = []
+        for p in parts:
+            try:
+                floats.append(int(p) if "." not in p else float(p))
+            except ValueError:
+                pass
+        return floats
+
+    def _parse_1d_array(self, line: str) -> List[float]:
+        """
+        Same as _parse_1d_float_array but can also parse int.
+        For simplicity, we treat them as floats. Adjust as needed.
+        """
+        return self._parse_1d_float_array(line)
+
+    def _parse_2d_array(self, line: str) -> List[List[float]]:
+        """
+        e.g. "[[1 0 0 0], [0 0 0 0], [0 0 0 0], [0 0 0 1]]"
+        -> [[1,0,0,0],[0,0,0,0],...]
+        """
+        # remove leading/trailing bracket
+        line = line.strip()
+        if line.startswith("[["):
+            line = line[1:]  # remove one '[' so left is "[1 0 0 0], ..."
+        if line.endswith("]]"):
+            line = line[:-1]  # remove one ']' so left is "...], [0 0 0 0]"
+        line = line.strip()
+        # Now we can split by "],"
+        row_strings = line.split("],")
+        matrix = []
+        for row_str in row_strings:
+            r = row_str.strip()
+            # remove leading '[' if any
+            if r.startswith("["):
+                r = r[1:]
+            # remove trailing ']' if any
+            if r.endswith("]"):
+                r = r[:-1]
+            # now split by whitespace
+            parts = r.split()
+            row = []
+            for p in parts:
+                try:
+                    val = int(p) if "." not in p else float(p)
+                except ValueError:
+                    val = 0.0
+                row.append(val)
+            matrix.append(row)
+        return matrix
+
+
+register_dataset("clrs", ClrsDataset, ClrsConfig)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ flake8>=7.1.1
 mypy>=1.14.1
 pre-commit>=4.1.0
 sympy>=1.13.3
+dm-clrs>=2.0.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ isort>=5.13.2
 flake8>=7.1.1
 mypy>=1.14.1
 pre-commit>=4.1.0
+sympy>=1.13.3

--- a/tests/test_clrs.py
+++ b/tests/test_clrs.py
@@ -1,0 +1,66 @@
+import pytest
+from reasoning_gym.algorithmic.clrs_task import ClrsConfig, ClrsDataset
+
+
+def test_clrs_dataset_basic():
+    dataset_size = 11
+    config = ClrsConfig(
+        subtask="heapsort",
+        min_length=4,
+        max_length=4,
+        seed=123,
+        size=dataset_size,
+    )
+
+    dataset = ClrsDataset(config)
+
+    assert len(dataset) == dataset_size
+
+
+def test_clrs_dataset_items():
+    config = ClrsConfig(
+        subtask="heapsort",
+        min_length=4,
+        max_length=5,
+        seed=42,
+        size=3,
+    )
+    dataset = ClrsDataset(config)
+
+    for item in dataset:
+        # Check keys
+        assert "question" in item
+        assert "answer" in item
+        assert "metadata" in item
+
+        # Check metadata contents
+        metadata = item["metadata"]
+        assert "length" in metadata
+        assert "arrays" in metadata
+
+        # The question should contain "heapsort:"
+        assert "heapsort:" in item["question"]
+
+        # answer is a string
+        assert isinstance(item["answer"], str)
+
+        # If there's a "key: [ ... ]" line, ensure it is in arrays
+        if "key" in metadata["arrays"]:
+            # Confirm that those numeric values appear in the question
+            for val in metadata["arrays"]["key"]:
+                assert str(val) in item["question"]
+
+
+def test_clrs_dataset_deterministic():
+    config = ClrsConfig(
+        "heapsort",
+        min_length=4,
+        max_length=4,
+        seed=999,
+        size=2,
+    )
+    dataset1 = ClrsDataset(config)
+    dataset2 = ClrsDataset(config)
+
+    for i in range(len(dataset1)):
+        assert dataset1[i] == dataset2[i], "Deterministic mismatch with same config"


### PR DESCRIPTION
CLRS is the [classic textbook](https://en.wikipedia.org/wiki/Introduction_to_Algorithms) on algorithms.
Deepmind introduced a [CLRS benchmark](https://github.com/google-deepmind/clrs?tab=readme-ov-file) which also includes a text version of most of the classical algorithms called [CLRS-text](https://github.com/google-deepmind/clrs/tree/master/clrs/_src/clrs_text). In this PR, I ported all the problems from CLRS to the reasoning-gym (see example tasks and data sample in README).

Available tasks:
- activity_selector
- articulation_points
- bellman_ford
- bfs
- binary_search
- bridges
- bubble_sort
- dag_shortest_paths
- dfs
- dijkstra
- find_maximum_subarray_kadane
- floyd_warshall
- graham_scan
- heapsort
- insertion_sort
- jarvis_march
- kmp_matcher
- lcs_length
- matrix_chain_order
- minimum
- mst_kruskal
- mst_prim
- naive_string_matcher
- optimal_bst
- quickselect
- quicksort
- segments_intersect
- strongly_connected_components
- task_scheduling
- topological_sort



Note for the future:
CLRS also supports giving hints by passing use_hints=True. For now, I left that out. The idea is that we could try to align what the algorithm should do overtime to really align with the expected behavior of a specific algorithm. Note that in that case, the last reference would be the answer and the rest would be the steps required to get there.