### PR TITLE
chore(envs): Remove unmodified dunder methods

### DIFF
--- a/reasoning_gym/games/n_queens.py
+++ b/reasoning_gym/games/n_queens.py
@@ -50,20 +50,6 @@ class NQueensDataset(ProceduralDataset):
         super().__init__(config=config, seed=config.seed, size=config.size)
         self._solutions = self._get_all_solutions(config.n)
 
-    def __len__(self) -> int:
-        return self.config.size
-
-    def __iter__(self):
-        self._current_idx = 0
-        return self
-
-    def __next__(self):
-        if self._current_idx >= self.config.size:
-            raise StopIteration
-        item = self[self._current_idx]
-        self._current_idx += 1
-        return item
-
     def _get_all_solutions(self, n: int) -> List[List[List[str]]]:
         """Get all solutions for the N Queens puzzle"""
 

--- a/reasoning_gym/graphs/course_schedule.py
+++ b/reasoning_gym/graphs/course_schedule.py
@@ -54,20 +54,6 @@ class CourseScheduleDataset(ProceduralDataset):
     def __init__(self, config: CourseScheduleConfig):
         super().__init__(config=config, seed=config.seed, size=config.size)
 
-    def __len__(self) -> int:
-        return self.config.size
-
-    def __iter__(self):
-        self._current_idx = 0
-        return self
-
-    def __next__(self):
-        if self._current_idx >= self.config.size:
-            raise StopIteration
-        item = self[self._current_idx]
-        self._current_idx += 1
-        return item
-
     def _can_finish(self, num_courses: int, prerequisites: List[List[int]]) -> bool:
         adj = defaultdict(list)
         for course, prereq in prerequisites:

--- a/reasoning_gym/graphs/largest_island.py
+++ b/reasoning_gym/graphs/largest_island.py
@@ -55,20 +55,6 @@ class LargestIslandDataset(ProceduralDataset):
     def __init__(self, config: LargestIslandConfig):
         super().__init__(config=config, seed=config.seed, size=config.size)
 
-    def __len__(self) -> int:
-        return self.config.size
-
-    def __iter__(self):
-        self._current_idx = 0
-        return self
-
-    def __next__(self):
-        if self._current_idx >= self.config.size:
-            raise StopIteration
-        item = self[self._current_idx]
-        self._current_idx += 1
-        return item
-
     def _is_valid_cell(self, r: int, c: int) -> bool:
         return 0 <= r < self.config.rows and 0 <= c < self.config.cols
 


### PR DESCRIPTION
### What does this PR do?

I realized that for the following environments I created I've unnecessarily included some of the dunder methods of the base class:
- `CourseScheduleDataset`
- `NQueensDataset`
- `NQueensDataset`

This PR simply removes them as they unnecessarily obfuscate the code base.