### PR TITLE
Remove leading/trailing whitespace from scored answers by default

### DIFF
--- a/reasoning_gym/dataset.py
+++ b/reasoning_gym/dataset.py
@@ -56,6 +56,8 @@ class ProceduralDataset(ABC, Sized, Iterable[Dict[str, Any]]):
         oracle_answer = entry["answer"]
         reward = 0.0
         if answer is not None:
+            if oracle_answer.strip() == oracle_answer:
+                answer = answer.strip()
             if answer == oracle_answer:
                 reward = 1.0
             elif oracle_answer in answer:


### PR DESCRIPTION
In default scoring, for some datasets, many answers receive a score of 0.5 due to the LLM generating leading/trailing whitespace, when they would otherwise receive 1.0. This whitespace is usually in the form of newlines.

One example: https://github.com/open-thought/reasoning-gym-eval/blob/495344154487e4dd16f4a1175c5e51436ce999a0/initial-r1-evals/r1/games/mini_sudoku.json#L26

This is a suggestion for reducing the prevalence of this. Leading/trailing whitespace is stripped only if the oracle answer does not contain any, meaning if we desire such whitespace in the answer for some reason it won't be affected.