### PR TITLE
Resolve mini sudoku generator outputting non-unique puzzles

### DIFF
--- a/reasoning_gym/games/mini_sudoku.py
+++ b/reasoning_gym/games/mini_sudoku.py
@@ -21,9 +21,9 @@ class MiniSudokuConfig:
 
     def validate(self):
         """Validate configuration parameters"""
-        # More than 12 empty cells tends to result in multiple solutions
+        # More than 12 empty cells is incompatible with a unique solution
         assert 0 <= self.min_empty <= 12, "min_empty must be between 0 and 12"
-        assert self.min_empty <= self.max_empty <= 16, "max_empty must be between min_empty and 16"
+        assert self.min_empty <= self.max_empty <= 12, "max_empty must be between min_empty and 12"
 
 
 class MiniSudokuDataset(ProceduralDataset):

--- a/reasoning_gym/games/mini_sudoku.py
+++ b/reasoning_gym/games/mini_sudoku.py
@@ -21,7 +21,8 @@ class MiniSudokuConfig:
 
     def validate(self):
         """Validate configuration parameters"""
-        assert 0 <= self.min_empty <= 16, "min_empty must be between 0 and 16"
+        # More than 12 empty cells tends to result in multiple solutions
+        assert 0 <= self.min_empty <= 12, "min_empty must be between 0 and 12"
         assert self.min_empty <= self.max_empty <= 16, "max_empty must be between min_empty and 16"
 
 

--- a/reasoning_gym/games/mini_sudoku.py
+++ b/reasoning_gym/games/mini_sudoku.py
@@ -1,5 +1,6 @@
 """Mini Sudoku (4x4) puzzle generator"""
 
+import copy
 from dataclasses import dataclass
 from random import Random
 from typing import Any, List, Optional, Tuple
@@ -111,14 +112,45 @@ class MiniSudokuDataset(ProceduralDataset):
 
         raise RuntimeError("Failed to generate valid mini sudoku board")
 
+    def _count_solutions(self, board: List[List[int]], limit: int = 2) -> int:
+        """Count the number of solutions for a given board"""
+
+        def _count_solutions_helper(board: List[List[int]]) -> int:
+            empty = self._find_empty(board)
+            if not empty:
+                return 1
+
+            row, col = empty
+            count = 0
+            for num in range(1, 5):
+                if self._is_valid(board, row, col, num):
+                    board[row][col] = num
+                    count += _count_solutions_helper(board)
+                    if count >= limit:
+                        return count
+                    board[row][col] = 0
+            return count
+
+        return _count_solutions_helper(board)
+
     def _create_puzzle(self, solved_board: List[List[int]], num_empty: int, rng: Random) -> List[List[int]]:
         """Create puzzle by removing numbers from solved board"""
         puzzle = [row[:] for row in solved_board]
         cells = [(i, j) for i in range(4) for j in range(4)]
         rng.shuffle(cells)
+        num_removed = 0
 
-        for i, j in cells[:num_empty]:
+        for i, j in cells:
+            saved = puzzle[i][j]
             puzzle[i][j] = 0
+            puzzle_copy = copy.deepcopy(puzzle)
+            # Check if removing this clue breaks uniqueness
+            if self._count_solutions(puzzle_copy) > 1:
+                puzzle[i][j] = saved
+            else:
+                num_removed += 1
+                if num_removed == num_empty:
+                    break
 
         return puzzle
 

--- a/reasoning_gym/games/mini_sudoku.py
+++ b/reasoning_gym/games/mini_sudoku.py
@@ -12,7 +12,9 @@ from ..factory import ProceduralDataset, register_dataset
 class MiniSudokuConfig:
     """Configuration for 4x4 sudoku puzzle generation"""
 
-    min_empty: int = 8  # Minimum number of empty cells
+    min_empty: int = (
+        8  # Minimum number of empty cells. Occasionally this can be violated, if removing more cells would break the puzzle's uniqueness.
+    )
     max_empty: int = 12  # Maximum number of empty cells
     seed: Optional[int] = None
     size: int = 500  # Virtual dataset size
@@ -168,6 +170,9 @@ class MiniSudokuDataset(ProceduralDataset):
         # Create puzzle by removing numbers
         num_empty = rng.randint(self.config.min_empty, self.config.max_empty)
         puzzle = self._create_puzzle(solved_board, num_empty, rng)
+
+        # Update the num_empty to be used in the metadata if we couldn't remove as many as we wanted
+        num_empty = sum(1 for row in puzzle for x in row if x == 0)
 
         # Format as strings
         puzzle_str = self._board_to_string(puzzle)


### PR DESCRIPTION
Closes #153 

I think this solution, of ensuring puzzles are unique rather than including in the prompt that they may not be and accepting any of the possible solutions in the scoring, is preferable.

Sudoku puzzles are meant to be unique as this ensures they can be solved with logic rather than by guessing. It seems to fit better with the goals of a reasoning dataset to produce puzzles which are logically solvable.

I wrote in a code comment that this can theoretically cause the configured minimum empty cells to be violated. In practice I have only observed this when using min_empty=12. For min_empty=12, approx. 10% of puzzles actually have 11 rather than 12.

If we are happy with this as a solution I'll look into the Sudoku dataset too, to see whether it has the same non-uniqueness issue and try a similar fix if so.