### PR TITLE
Fix Sudoku generator for uniqueness, implement scoring

### DIFF
--- a/reasoning_gym/games/sudoku.py
+++ b/reasoning_gym/games/sudoku.py
@@ -12,8 +12,7 @@ from ..factory import ProceduralDataset, register_dataset
 class SudokuConfig:
     """
     Configuration for sudoku puzzle generation
-    Puzzle generation can be slow for puzzles with a high (~60+) number of empty cells
-    This is because it's much harder to generate puzzles with a unique solution when there are very few clues
+    Puzzle generation can be a bit slower for puzzles with a high (~60+) number of empty cells
     """
 
     min_empty: int = 30  # Minimum number of empty cells

--- a/reasoning_gym/games/sudoku.py
+++ b/reasoning_gym/games/sudoku.py
@@ -124,6 +124,10 @@ class SudokuDataset(ProceduralDataset):
         """Count the number of solutions for a given board"""
 
         def _get_min_possibilities_cell(board: List[List[int]]) -> Optional[Tuple[int, int, Set[int]]]:
+            """
+            Get the cell with the lowest number of possibilities.
+            Returns None if the board is already solved.
+            """
             min_possibilities = 10
             min_cell = None
             min_values = None

--- a/reasoning_gym/games/sudoku.py
+++ b/reasoning_gym/games/sudoku.py
@@ -88,11 +88,10 @@ class SudokuDataset(ProceduralDataset):
 
         row, col = empty
         for num in self._get_possible_values(board, row, col):
-            if self._is_valid(board, row, col, num):
-                board[row][col] = num
-                if self._solve(board):
-                    return True
-                board[row][col] = 0
+            board[row][col] = num
+            if self._solve(board):
+                return True
+            board[row][col] = 0
         return False
 
     def _find_empty(self, board: List[List[int]]) -> Optional[Tuple[int, int]]:


### PR DESCRIPTION
This applies the same solutions used for mini Sudoku, but I implemented a couple of optimisations as the brute force solution counting from the 4x4 case got very slow for some 9x9 cases. Verified this is now generating unique puzzles.

Overall generation is mostly pretty quick with the optimisations, but can still be a bit slow (~1s) if specifying high values (>60) for the number of empty cells. It's harder to find puzzles with a unique solution as we approach the minimum possible number of clues (17).

Again used the same function from Futoshiki for answer scoring. Seems to work well for some simple test cases.