### PR TITLE
Add Bitwise Arithmetic

### DIFF
--- a/reasoning_gym/arithmetic/__init__.py
+++ b/reasoning_gym/arithmetic/__init__.py
@@ -3,6 +3,7 @@ Arithmetic tasks for training reasoning capabilities:
 """
 
 from .basic_arithmetic import BasicArithmeticDataset, BasicArithmeticDatasetConfig
+from .bitwise_arithmetic import BitwiseArithmeticConfig, BitwiseArithmeticDataset
 from .calendar_arithmetic import CalendarArithmeticConfig, CalendarArithmeticDataset
 from .chain_sum import ChainSumConfig, ChainSumDataset
 from .count_bits import CountBitsConfig, CountBitsDataset
@@ -55,4 +56,6 @@ __all__ = [
     "DecimalArithmeticDataset",
     "DecimalChainSumConfig",
     "DecimalChainSumDataset",
+    "BitwiseArithmeticConfig",
+    "BitwiseArithmeticDataset",
 ]

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -9,7 +9,7 @@ from ..factory import ProceduralDataset, register_dataset
 class BitwiseArithmeticConfig:
     """Configuration for Bitwise arithmetic dataset generation"""
 
-    difficulty: int = 2
+    difficulty: int = 2  # Controls expression complexity: 1=simple expressions, 2=nested expressions, 3+=deeper nesting
     seed: Optional[int] = None
     size: int = 500
 
@@ -104,7 +104,26 @@ def verify_solution(problem, user_solution):
 
 
 class BitwiseArithmeticDataset(ProceduralDataset):
-    """Dataset that generates basic tasks using bitwise arithmetic, shift registers and proper operator precedence."""
+    """Dataset that generates tasks testing understanding of bitwise arithmetic operations.
+
+    Generates expressions combining:
+    - Standard arithmetic operators (+, -, *)
+    - Bitwise shift operators (<<, >>)
+    - Multi-byte hexadecimal numbers (e.g. 0x100 to 0xFFFF)
+
+    The difficulty parameter controls expression complexity:
+    - Level 1: Simple expressions like (0x123 + 0x456)
+    - Level 2: Nested expressions with shifts like ((0x123 + 0x456) << 1)
+    - Level 3+: Deeper nesting like ((0x123 + 0x456) << (0x789 >> 1))
+
+    Each task provides:
+    - A question asking to evaluate an expression
+    - The correct answer in hexadecimal format
+    - Metadata including the raw expression
+
+    The dataset verifies answers by evaluating them as Python expressions,
+    supporting both integer and hexadecimal string formats.
+    """
 
     def __init__(self, config: BitwiseArithmeticConfig) -> None:
         super().__init__(config=config, seed=config.seed, size=config.size)

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -96,8 +96,9 @@ def verify_solution(problem, user_solution):
     """
     try:
         correct_value = eval(problem)
+        # Use base=0 for automatic base detection: 0x->hex, 0b->binary, 0o->octal, no prefix->decimal
         user_value = int(str(user_solution), 0)
-    except Exception as e:
+    except Exception:
         return False
 
     return correct_value == user_value

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -1,0 +1,153 @@
+import ast
+from dataclasses import dataclass
+from random import Random
+from typing import Any, Dict, List, Optional
+
+from ..factory import ProceduralDataset, register_dataset
+
+
+@dataclass
+class BitwiseArithmeticConfig:
+    """Configuration for Bitwise arithmetic dataset generation"""
+
+    difficulty: int = 2
+    seed: Optional[int] = None
+    size: int = 500
+
+    def validate(self) -> None:
+        """Validate configuration parameters"""
+        assert 0 < self.difficulty, "difficulty must be gt 0"
+        assert 10 >= self.difficulty, "difficulty must be lte 10"
+
+
+def generate_expression(rng, max_depth):
+    """
+    Recursively generate a random arithmetic expression that includes
+    standard arithmetic (+, -, *) and bitwise shifting (<<, >>) operators.
+    All numbers are represented in hexadecimal format as multi-byte values.
+
+    Parameters:
+        max_depth (int): Maximum depth of nested expressions.
+
+    Returns:
+        str: A string representing the generated expression.
+    """
+    # Base case: return a random multi-byte number in hex (0x100 to 0xFFFF).
+    if max_depth <= 0:
+        return hex(rng.randint(0x100, 0xFFFF))
+
+    # Occasionally return a simple hex number even if max_depth > 0.
+    if rng.random() < 0.01:
+        return hex(rng.randint(0x100, 0xFFFF))
+
+    # Choose a random operator.
+    operators = ["+", "-", "*", "<<", ">>"]
+    op = rng.choice(operators)
+
+    # Generate left and right subexpressions.
+    left_expr = generate_expression(rng, max_depth - 1)
+    right_expr = generate_expression(rng, max_depth - 1)
+
+    # For bitwise shift operations, keep the right operand small (in hex).
+    if op in ["<<", ">>"]:
+        right_expr = hex(rng.randint(0, 3))
+
+    return f"({left_expr} {op} {right_expr})"
+
+
+def generate_problem(rng, difficulty=1):
+    """
+    Generate a random arithmetic problem involving multi-byte hexadecimal numbers.
+
+    The 'difficulty' parameter controls the complexity:
+      - Lower difficulty produces a shallower expression.
+      - Higher difficulty produces a more deeply nested expression.
+
+    Parameters:
+        difficulty (int): The difficulty level (1 = simplest; higher values = more complex).
+
+    Returns:
+        tuple: (problem_str, correct_answer)
+          - problem_str (str): The generated arithmetic expression (with hex numbers).
+          - correct_answer (str): The evaluated result, formatted as a hex string.
+    """
+    max_depth = max(1, difficulty)
+    problem_str = generate_expression(rng, max_depth)
+    correct_value = eval(problem_str)
+    correct_answer = hex(correct_value)
+
+    return problem_str, correct_answer
+
+
+def verify_solution(problem, user_solution):
+    """
+    Verify if the provided solution is correct for the given problem.
+
+    Parameters:
+        problem (str): The arithmetic expression (with hex numbers).
+        user_solution (str or int): The user's answer, either as a hex string (e.g., "0xa")
+            or an integer.
+
+    Returns:
+        bool: True if the user's answer matches the evaluated result, else False.
+    """
+    try:
+        correct_value = eval(problem)
+        user_value = int(str(user_solution), 0)
+    except Exception as e:
+        return False
+
+    return correct_value == user_value
+
+
+class BitwiseArithmeticDataset(ProceduralDataset):
+    """Dataset that generates basic tasks using bitwise arithmetic and proper operator precedence."""
+
+    def __init__(self, config: BitwiseArithmeticConfig) -> None:
+        super().__init__(config=config, seed=config.seed, size=config.size)
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        """
+        Generate a single arithmetic task.
+
+        Returns:
+            dict: Contains:
+              - 'question': The formatted arithmetic expression as a string.
+              - 'answer': The computed hexidecimal result.
+              - 'metadata': Additional metadata.
+        """
+        # Create a deterministic RNG from base seed and index.
+        rng: Random = Random(self.seed + idx if self.seed is not None else None)
+
+        problem, answer = generate_problem(
+            rng,
+            self.config.difficulty,
+        )
+        problem_str = f"Please solve this problem. Reply only with the final hexidecimal value.\n" + problem
+
+        return {"question": problem_str, "answer": answer, "metadata": {"problem": problem}}
+
+    def score_answer(self, answer: Optional[str], entry: Dict[str, Any]) -> float:
+        """
+        Compares the user's answer (converted to Bitwise) with the correct answer.
+        Instead of requiring exact equality, we allow an error up to one unit in the
+        least significant digit as determined by the level of precision (max_num_Bitwise_places).
+
+        Returns:
+            float: 1.0 if the user's answer is within tolerance; otherwise, 0.01.
+        """
+        if answer is None:
+            return 0.0
+
+        try:
+            solved = verify_solution(entry["metadata"]["problem"], answer)
+            if solved:
+                return 1.0
+        except Exception:
+            return 0.01
+
+        return 0.01
+
+
+# Register the dataset with the factory.
+register_dataset("Bitwise_arithmetic", BitwiseArithmeticDataset, BitwiseArithmeticConfig)

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -150,4 +150,4 @@ class BitwiseArithmeticDataset(ProceduralDataset):
 
 
 # Register the dataset with the factory.
-register_dataset("Bitwise_arithmetic", BitwiseArithmeticDataset, BitwiseArithmeticConfig)
+register_dataset("bitwise_arithmetic", BitwiseArithmeticDataset, BitwiseArithmeticConfig)

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -101,7 +101,7 @@ def verify_solution(problem, user_solution):
 
 
 class BitwiseArithmeticDataset(ProceduralDataset):
-    """Dataset that generates basic tasks using bitwise arithmetic and proper operator precedence."""
+    """Dataset that generates basic tasks using bitwise arithmetic, shift registers and proper operator precedence."""
 
     def __init__(self, config: BitwiseArithmeticConfig) -> None:
         super().__init__(config=config, seed=config.seed, size=config.size)
@@ -114,7 +114,7 @@ class BitwiseArithmeticDataset(ProceduralDataset):
             dict: Contains:
               - 'question': The formatted arithmetic expression as a string.
               - 'answer': The computed hexidecimal result.
-              - 'metadata': Additional metadata.
+              - 'metadata': Additional metadata, including just the problem without prompt.
         """
         # Create a deterministic RNG from base seed and index.
         rng: Random = Random(self.seed + idx if self.seed is not None else None)
@@ -129,12 +129,10 @@ class BitwiseArithmeticDataset(ProceduralDataset):
 
     def score_answer(self, answer: Optional[str], entry: Dict[str, Any]) -> float:
         """
-        Compares the user's answer (converted to Bitwise) with the correct answer.
-        Instead of requiring exact equality, we allow an error up to one unit in the
-        least significant digit as determined by the level of precision (max_num_Bitwise_places).
+        Compares the user's answer with the correct answer.
 
         Returns:
-            float: 1.0 if the user's answer is within tolerance; otherwise, 0.01.
+            float: 1.0 if the user's answer is correct; otherwise, 0.01 unless no answer is provided, in which case 0.
         """
         if answer is None:
             return 0.0

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -20,13 +20,14 @@ class BitwiseArithmeticConfig:
         assert 10 >= self.difficulty, "difficulty must be lte 10"
 
 
-def generate_expression(rng, max_depth):
+def generate_expression(rng: Random, max_depth: int) -> str:
     """
     Recursively generate a random arithmetic expression that includes
     standard arithmetic (+, -, *) and bitwise shifting (<<, >>) operators.
     All numbers are represented in hexadecimal format as multi-byte values.
 
     Parameters:
+        rng (Random): Random number generator instance
         max_depth (int): Maximum depth of nested expressions.
 
     Returns:
@@ -55,15 +56,18 @@ def generate_expression(rng, max_depth):
     return f"({left_expr} {op} {right_expr})"
 
 
-def generate_problem(rng, difficulty=1):
+def generate_problem(rng: Random, difficulty: int = 1) -> tuple[str, str]:
     """
     Generate a random arithmetic problem involving multi-byte hexadecimal numbers.
 
     The 'difficulty' parameter controls the complexity:
-      - Lower difficulty produces a shallower expression.
-      - Higher difficulty produces a more deeply nested expression.
+      - difficulty=1: Simple expressions like (0x123 + 0x456)
+      - difficulty=2: Nested expressions like ((0x123 + 0x456) << 1)
+      - difficulty=3: More complex nesting like ((0x123 + 0x456) << (0x789 >> 1))
+      Higher values continue to increase nesting depth and expression complexity.
 
     Parameters:
+        rng (Random): Random number generator instance
         difficulty (int): The difficulty level (1 = simplest; higher values = more complex).
 
     Returns:

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -123,7 +123,7 @@ class BitwiseArithmeticDataset(ProceduralDataset):
             rng,
             self.config.difficulty,
         )
-        problem_str = f"Please solve this problem. Reply only with the final hexidecimal value.\n" + problem
+        problem_str = f"Please solve this problem. Assume there is arbitrary bit depth and that there are signed integers. Reply only with the final hexidecimal value.\n" + problem
 
         return {"question": problem_str, "answer": answer, "metadata": {"problem": problem}}
 

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -123,7 +123,10 @@ class BitwiseArithmeticDataset(ProceduralDataset):
             rng,
             self.config.difficulty,
         )
-        problem_str = f"Please solve this problem. Assume there is arbitrary bit depth and that there are signed integers. Reply only with the final hexidecimal value.\n" + problem
+        problem_str = (
+            f"Please solve this problem. Assume there is arbitrary bit depth and that there are signed integers. Reply only with the final hexidecimal value.\n"
+            + problem
+        )
 
         return {"question": problem_str, "answer": answer, "metadata": {"problem": problem}}
 

--- a/reasoning_gym/arithmetic/bitwise_arithmetic.py
+++ b/reasoning_gym/arithmetic/bitwise_arithmetic.py
@@ -1,7 +1,6 @@
-import ast
 from dataclasses import dataclass
 from random import Random
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from ..factory import ProceduralDataset, register_dataset
 
@@ -110,7 +109,7 @@ class BitwiseArithmeticDataset(ProceduralDataset):
     def __init__(self, config: BitwiseArithmeticConfig) -> None:
         super().__init__(config=config, seed=config.seed, size=config.size)
 
-    def __getitem__(self, idx: int) -> Dict[str, Any]:
+    def __getitem__(self, idx: int) -> dict[str, Any]:
         """
         Generate a single arithmetic task.
 
@@ -134,7 +133,7 @@ class BitwiseArithmeticDataset(ProceduralDataset):
 
         return {"question": problem_str, "answer": answer, "metadata": {"problem": problem}}
 
-    def score_answer(self, answer: Optional[str], entry: Dict[str, Any]) -> float:
+    def score_answer(self, answer: Optional[str], entry: dict[str, Any]) -> float:
         """
         Compares the user's answer with the correct answer.
 

--- a/tests/test_bitwise_arithmetic.py
+++ b/tests/test_bitwise_arithmetic.py
@@ -1,0 +1,54 @@
+import pytest
+
+from reasoning_gym.arithmetic.bitwise_arithmetic import BitwiseArithmeticConfig, BitwiseArithmeticDataset
+
+
+def test_bitwise_arithmetic():
+    """Test basic properties and solution of generated items"""
+
+    # Easy
+    config = BitwiseArithmeticConfig(
+        seed=42,
+        size=2000,
+        difficulty=1,
+    )
+    dataset = BitwiseArithmeticDataset(config)
+
+    for item in dataset:
+        assert isinstance(item, dict)
+        assert "question" in item
+        assert "answer" in item
+        assert "metadata" in item
+
+        # Test the scoring
+        assert dataset.score_answer(answer=item["answer"], entry=item) == 1.0
+        assert dataset.score_answer(answer=None, entry=item) == 0.0
+        assert dataset.score_answer(answer="kitty cat", entry=item) == 0.01
+
+    config = BitwiseArithmeticConfig(
+        seed=42,
+        size=100,
+        difficulty=5,
+    )
+    dataset = BitwiseArithmeticDataset(config)
+
+    for item in dataset:
+        assert isinstance(item, dict)
+        assert "question" in item
+        assert "answer" in item
+        assert "metadata" in item
+        assert dataset.score_answer(answer=item["answer"], entry=item) == 1.0
+
+    config = BitwiseArithmeticConfig(
+        seed=42,
+        size=100,
+        difficulty=10,
+    )
+    dataset = BitwiseArithmeticDataset(config)
+
+    for item in dataset:
+        assert isinstance(item, dict)
+        assert "question" in item
+        assert "answer" in item
+        assert "metadata" in item
+        assert dataset.score_answer(answer=item["answer"], entry=item) == 1.0

--- a/tests/test_bitwise_arithmetic.py
+++ b/tests/test_bitwise_arithmetic.py
@@ -59,7 +59,7 @@ def test_bitwise_arithmetic_difficulty_levels():
             # Higher difficulty should generally produce more operators
             problem = item["metadata"]["problem"]
             num_operators = sum(1 for c in problem if c in ["+", "-", "*", "<", ">"])
-            
+
             if difficulty == 1:
                 assert num_operators <= 2  # Simple expressions
             elif difficulty >= 5:
@@ -97,18 +97,22 @@ def test_bitwise_arithmetic_answer_formats():
     """Test that different answer formats are handled correctly"""
     config = BitwiseArithmeticConfig(difficulty=1, size=10, seed=42)
     dataset = BitwiseArithmeticDataset(config)
-    
+
     for item in dataset:
         problem = item["metadata"]["problem"]
         correct = item["answer"]
-        
+
         # Test hex string format
         assert dataset.score_answer(answer=correct, entry=item) == 1.0
-        
+
         # Test decimal format
         decimal_answer = str(eval(problem))  # Safe as we control the problem
         assert dataset.score_answer(answer=decimal_answer, entry=item) == 1.0
-        
+
         # Test with "0x" prefix variations
-        if not correct.startswith("0x"):
-            assert dataset.score_answer(answer="0x" + correct[2:], entry=item) == 1.0
+        if correct.startswith("-0x"):
+            # For negative numbers, keep the minus sign
+            assert dataset.score_answer(answer="-0x" + correct[3:], entry=item) == 1.0
+        elif not correct.startswith("0x"):
+            # For positive numbers without prefix
+            assert dataset.score_answer(answer="0x" + correct, entry=item) == 1.0

--- a/tests/test_bitwise_arithmetic.py
+++ b/tests/test_bitwise_arithmetic.py
@@ -3,52 +3,112 @@ import pytest
 from reasoning_gym.arithmetic.bitwise_arithmetic import BitwiseArithmeticConfig, BitwiseArithmeticDataset
 
 
-def test_bitwise_arithmetic():
-    """Test basic properties and solution of generated items"""
+def test_bitwise_arithmetic_config_validation():
+    """Test that invalid configs raise appropriate errors"""
+    with pytest.raises(AssertionError):
+        config = BitwiseArithmeticConfig(difficulty=0)
+        config.validate()
 
-    # Easy
-    config = BitwiseArithmeticConfig(
-        seed=42,
-        size=2000,
-        difficulty=1,
-    )
+    with pytest.raises(AssertionError):
+        config = BitwiseArithmeticConfig(difficulty=11)
+        config.validate()
+
+
+def test_bitwise_arithmetic_deterministic():
+    """Test that dataset generates same items with same seed"""
+    config = BitwiseArithmeticConfig(seed=42, size=10)
+    dataset1 = BitwiseArithmeticDataset(config)
+    dataset2 = BitwiseArithmeticDataset(config)
+
+    for i in range(len(dataset1)):
+        assert dataset1[i] == dataset2[i]
+
+
+def test_bitwise_arithmetic_items():
+    """Test basic properties of generated items"""
+    config = BitwiseArithmeticConfig(difficulty=1, size=100, seed=42)
     dataset = BitwiseArithmeticDataset(config)
 
-    for item in dataset:
+    for i in range(len(dataset)):
+        item = dataset[i]
         assert isinstance(item, dict)
         assert "question" in item
         assert "answer" in item
         assert "metadata" in item
 
-        # Test the scoring
-        assert dataset.score_answer(answer=item["answer"], entry=item) == 1.0
+        # Verify the answer matches the problem
+        problem = item["metadata"]["problem"]
+        answer = item["answer"]
+        assert dataset.score_answer(answer=answer, entry=item) == 1.0
+
+        # Test scoring edge cases
         assert dataset.score_answer(answer=None, entry=item) == 0.0
-        assert dataset.score_answer(answer="kitty cat", entry=item) == 0.01
+        assert dataset.score_answer(answer="invalid", entry=item) == 0.01
 
-    config = BitwiseArithmeticConfig(
-        seed=42,
-        size=100,
-        difficulty=5,
-    )
+
+def test_bitwise_arithmetic_difficulty_levels():
+    """Test that different difficulty levels produce appropriate complexity"""
+    for difficulty in [1, 5, 10]:
+        config = BitwiseArithmeticConfig(difficulty=difficulty, size=50, seed=42)
+        dataset = BitwiseArithmeticDataset(config)
+
+        for item in dataset:
+            # All items should be valid regardless of difficulty
+            assert dataset.score_answer(answer=item["answer"], entry=item) == 1.0
+
+            # Higher difficulty should generally produce more operators
+            problem = item["metadata"]["problem"]
+            num_operators = sum(1 for c in problem if c in ["+", "-", "*", "<", ">"])
+            
+            if difficulty == 1:
+                assert num_operators <= 2  # Simple expressions
+            elif difficulty >= 5:
+                # More complex expressions should exist at higher difficulties
+                found_complex = False
+                for item in dataset:
+                    if sum(1 for c in item["metadata"]["problem"] if c in ["+", "-", "*", "<", ">"]) > 2:
+                        found_complex = True
+                        break
+                assert found_complex
+
+
+def test_bitwise_arithmetic_iteration():
+    """Test that iteration respects dataset size"""
+    config = BitwiseArithmeticConfig(difficulty=1, size=5, seed=42)  # Small size for testing
     dataset = BitwiseArithmeticDataset(config)
 
+    # Test manual iteration
+    items = []
     for item in dataset:
-        assert isinstance(item, dict)
-        assert "question" in item
-        assert "answer" in item
-        assert "metadata" in item
-        assert dataset.score_answer(answer=item["answer"], entry=item) == 1.0
+        items.append(item)
+    assert len(items) == config.size, "Iterator should yield exactly size items"
 
-    config = BitwiseArithmeticConfig(
-        seed=42,
-        size=100,
-        difficulty=10,
-    )
+    # Test list conversion
+    items = list(dataset)
+    assert len(items) == config.size, "Iterator should yield exactly size items"
+
+    # Test multiple iterations
+    first_items = list(dataset)
+    second_items = list(dataset)
+    assert first_items == second_items, "Multiple iterations should yield same items"
+
+
+def test_bitwise_arithmetic_answer_formats():
+    """Test that different answer formats are handled correctly"""
+    config = BitwiseArithmeticConfig(difficulty=1, size=10, seed=42)
     dataset = BitwiseArithmeticDataset(config)
-
+    
     for item in dataset:
-        assert isinstance(item, dict)
-        assert "question" in item
-        assert "answer" in item
-        assert "metadata" in item
-        assert dataset.score_answer(answer=item["answer"], entry=item) == 1.0
+        problem = item["metadata"]["problem"]
+        correct = item["answer"]
+        
+        # Test hex string format
+        assert dataset.score_answer(answer=correct, entry=item) == 1.0
+        
+        # Test decimal format
+        decimal_answer = str(eval(problem))  # Safe as we control the problem
+        assert dataset.score_answer(answer=decimal_answer, entry=item) == 1.0
+        
+        # Test with "0x" prefix variations
+        if not correct.startswith("0x"):
+            assert dataset.score_answer(answer="0x" + correct[2:], entry=item) == 1.0

--- a/tests/test_bitwise_arithmetic.py
+++ b/tests/test_bitwise_arithmetic.py
@@ -48,7 +48,7 @@ def test_bitwise_arithmetic_items():
 
 def test_bitwise_arithmetic_difficulty_levels():
     """Test that different difficulty levels produce appropriate complexity"""
-    for difficulty in [1, 5, 10]:
+    for difficulty in [1, 2, 3]:
         config = BitwiseArithmeticConfig(difficulty=difficulty, size=50, seed=42)
         dataset = BitwiseArithmeticDataset(config)
 


### PR DESCRIPTION
More arithmetic, this time with hex values and shift registers.

```
Please solve this problem. Reply only with the final hexidecimal value.
(((((0xeb51 - 0xa153) - (0x8afe * 0x2532)) << 0x1) - (((0x40f9 + 0xc5ef) - (0x8da0 + 0xe129)) - ((0x6afc - 0xa441) - (0xb4b6 >> 0x0)))) >> 0x3)
```

```
-0x50c752b
```

ChatGPT gets confused with the really really big ones. It gets the correct when it's allowed to write and execute Python, but gets them wrong after a certain point if it doesn't try to use Python.