### PR TITLE
Dynamic Scoring for Letter Jumble

### DIFF
--- a/tests/test_letter_jumble.py
+++ b/tests/test_letter_jumble.py
@@ -110,8 +110,12 @@ def test_letter_jumble_dataset_items():
 
         # Test the scoring
         assert dataset.score_answer(answer=item["answer"], entry=item) == 1.0
-        assert dataset.score_answer(answer="gibberish", entry=item) == 0.01
         assert dataset.score_answer(answer=None, entry=item) == 0.0
+        answera = item["answer"].split(" ")
+        answera[0] = "flippityfloop"
+        answera[1] = "doopadoopadoop"
+        answerf = " ".join(answera)
+        assert 0.01 <= dataset.score_answer(answer=answerf, entry=item) <= 1.0
 
 
 def test_letter_jumble_iteration():


### PR DESCRIPTION
Perfect string matching was returning far too low scores for words like "who" and "how", which could both sort of make sense.

This is kind of hard to do without remaking the puzzle from an unambiguous dictionary, and there's something about the partial context which requires some reasoning to find the 'better' answer.

So, we can do scoring on a per-word basis for partially correct answers.