### PR TITLE
small change to word sequence reversal prompt

### DIFF
--- a/reasoning_gym/algorithmic/word_sequence_reversal.py
+++ b/reasoning_gym/algorithmic/word_sequence_reversal.py
@@ -8,6 +8,8 @@ from typing import Optional
 from ..data import read_data_file
 from ..factory import ProceduralDataset, register_dataset
 
+QUESTION_TEMPLATE = """Solve the following problem. Provide you answer as a comma-separated list of word with a space the comma. Reverse this list of words: {question}"""
+
 
 @dataclass
 class WordSequenceReversalConfig:
@@ -49,7 +51,7 @@ class WordSequenceReversalDataset(ProceduralDataset):
         answer = ", ".join(reversed(words))
 
         return {
-            "question": f"Reverse this list of words: {question}",
+            "question": f"{QUESTION_TEMPLATE.format(question=question)}",
             "answer": answer,
             "metadata": {"num_words": num_words, "words": words},
         }


### PR DESCRIPTION
Very small change to `word_sequence_reversal` dataset. The question did not specify the desired answer format which was leading to answers which objectively correct marked as wrong
Example in the evaluations [here](https://github.com/open-thought/reasoning-gym-eval/blob/main/o3-mini/algorithmic/word_sequence_reversal.json)
```
{
      "question": "Reverse this list of words: computers, That, race, his",
      "expected_answer": "his, race, That, computers",
      "model_answer": "his race That computers",
      "full_model_response": "<think>[Internal chain-of-thought hidden]</think>\n<answer>his race That computers</answer>",
      "score": 0.01,
      "metadata": "{'num_words': 4, 'words': ['computers', 'That', 'race', 'his']}"
    },
```
