### PR TITLE
should exit if API key isn't defined

### DIFF
--- a/eval/eval.py
+++ b/eval/eval.py
@@ -500,7 +500,7 @@ async def main_async():
                 print("Warning: OPENROUTER_API_KEY environment variable is not set")
                 print("Please set it using: export OPENROUTER_API_KEY=your-api-key")
                 print("Or provide it directly with --api-key")
-                sys.exit(1)
+                return 1
 
     # Load configuration
     config_path = args.config

--- a/eval/eval.py
+++ b/eval/eval.py
@@ -500,7 +500,7 @@ async def main_async():
                 print("Warning: OPENROUTER_API_KEY environment variable is not set")
                 print("Please set it using: export OPENROUTER_API_KEY=your-api-key")
                 print("Or provide it directly with --api-key")
-                print("Continuing without API key...")
+                sys.exit(1)
 
     # Load configuration
     config_path = args.config


### PR DESCRIPTION
old code had print("continuing without API key") which doesn't make sense