### PR TITLE
Fixed `countdown` `score_answer` 

### DIFF
--- a/reasoning_gym/games/countdown.py
+++ b/reasoning_gym/games/countdown.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from random import Random
 from typing import Any, Optional
@@ -177,15 +178,25 @@ class CountdownDataset(ProceduralDataset):
         metadata = entry["metadata"]
         if answer is not None:
             try:
+                answer = answer.strip()
                 user_answer = int(parse_expr(answer))
-                solved = user_answer == metadata["target"]
+                used_numbers = [int(num) for num in re.findall(r"\b\d+\b", answer)]
+                valid_numbers = True
+
+                for num in used_numbers:
+                    if num not in metadata["numbers"]:
+                        valid_numbers = False
+                        break
+
+                solved = user_answer == metadata["target"] and valid_numbers
+
                 if solved:
                     reward = 1.0
-                elif len(answer.strip()) > 0:  # encourage partial solutions
+                elif len(answer) > 0:
                     reward = 0.05
                 else:
                     reward = 0.01
-            except:
+            except Exception as e:
                 reward = 0.01
         return reward
 

--- a/tests/test_countdown.py
+++ b/tests/test_countdown.py
@@ -72,13 +72,32 @@ def test_countdown_game_items():
             dataset.score_answer(answer="a wrong solution", entry=item) == 0.01
         )  # wrong answer but incorrectly formatted
         assert dataset.score_answer(answer="", entry=item) == 0.01  # wrong answer but empty string
-        assert dataset.score_answer(answer=None, entry=item) == 0.0  # no answer
+        assert dataset.score_answer(answer=None, entry=item) == 0.01  # no answer
 
         try:
             result = eval(expr)  # Safe here since we control expression generation
             assert result == item["metadata"]["target"]
         except (SyntaxError, ZeroDivisionError):
             pytest.fail(f"Invalid expression generated: {expr}")
+
+
+def test_answer_with_incorrect_numbers():
+    dataset = CountdownDataset(CountdownConfig(size=10, seed=42))
+    answer = "45+2"
+    item = {
+        "metadata": {
+            "numbers": [44, 3],
+            "target": 47,
+        }
+    }
+    assert dataset.score_answer(answer=answer, entry=item) == 0.05
+
+
+def test_answer_without_all_numbers():
+    dataset = CountdownDataset(CountdownConfig(size=10, seed=42))
+    answer = "45+2+3"
+    item = {"metadata": {"numbers": [1, 45, 2, 3], "target": 50}}
+    assert dataset.score_answer(answer=answer, entry=item) == 0.05
 
 
 def test_countdown_game_randomization():


### PR DESCRIPTION
As discovered in evaluation sheet, countdown score answer implementation had an error where it would score answers correct even if the solution uses numbers not specified in the question. Small adjustment.