### PR TITLE
updated algorithmics dataset

### DIFF
--- a/reasoning_gym/algorithmic/pool_matrix.py
+++ b/reasoning_gym/algorithmic/pool_matrix.py
@@ -13,6 +13,7 @@ The stride is equal to the kernel size, meaning there is no overlap between the 
 
 Your output should be a matrix in the same format as the input matrix.
 The output matrix is smaller than the input matrix when the kernel size is greater than 1, and its elements may be floating-point numbers.
+Give elements in the output matrix correct to 2 decimal places.
 
 Perform {pool_type} pooling on the following matrix with a kernel size of {pool_size}:
 {matrix}
@@ -87,7 +88,7 @@ class PoolMatrixDataset(ProceduralDataset):
         try:
             oracle_answer = np.loadtxt(entry["answer"].splitlines(), dtype=np.float32)
             answer = np.loadtxt(answer.splitlines(), dtype=np.float32)
-            if oracle_answer.shape == answer.shape and np.allclose(oracle_answer, answer):
+            if oracle_answer.shape == answer.shape and np.allclose(oracle_answer, answer, rtol=1e-2):
                 reward = 1.0
             elif oracle_answer.shape == answer.shape:
                 reward = 0.1

--- a/reasoning_gym/arithmetic/gsm_symbolic/gsm_symbolic.py
+++ b/reasoning_gym/arithmetic/gsm_symbolic/gsm_symbolic.py
@@ -1,5 +1,6 @@
 """GSM Symblic dataset generator"""
 
+import re
 from dataclasses import dataclass
 from random import Random
 from typing import Any, Callable, Optional
@@ -157,7 +158,12 @@ class GSMSymbolicDataset(ProceduralDataset):
         if answer is None:
             return reward
         try:
-            answer_value = float(answer)
+            # Extract number using regex with search
+            match = re.search(r"\b-?\d+(?:\.\d+)?\b", answer)
+            if not match:
+                return reward
+
+            answer_value = float(match.group(0))
             expected_answer = float(entry["answer"])
             if answer_value == expected_answer:
                 reward = 1.0

--- a/reasoning_gym/arithmetic/gsm_symbolic/gsm_symbolic.py
+++ b/reasoning_gym/arithmetic/gsm_symbolic/gsm_symbolic.py
@@ -149,8 +149,23 @@ class GSMSymbolicDataset(ProceduralDataset):
         generator_idx = self.task_indices[idx]
         generator = self.generators[generator_idx]
         example = generator(rng, self.config.difficulty)
-        example["question"] += " Give only the result as your final answer."
+        example["question"] += " Give the result as your final answer. Do not include units."
         return example
+
+    def score_answer(self, answer: Optional[str], entry: dict[str, Any]) -> float:
+        reward = 0.0
+        if answer is None:
+            return reward
+        try:
+            answer_value = float(answer)
+            expected_answer = float(entry["answer"])
+            if answer_value == expected_answer:
+                reward = 1.0
+            else:
+                reward = 0.01
+        except Exception:
+            return reward
+        return reward
 
 
 register_dataset("gsm_symbolic", GSMSymbolicDataset, GSMSymbolicDatasetConfig)

--- a/tests/test_gsm_symbolic.py
+++ b/tests/test_gsm_symbolic.py
@@ -90,3 +90,14 @@ def test_gsm_symbolic_generators():
         print(f"ok: q={len(question_set)}, a={len(answer_set)}")
 
         i += 1
+
+
+def test_gsm_symbolic_score_answer():
+    """Test score answer function"""
+    config = GSMSymbolicDatasetConfig(size=100, seed=42)
+    dataset = GSMSymbolicDataset(config)
+
+    for i in range(len(dataset)):
+        item = dataset[i]
+        score = dataset.score_answer(item["answer"], item)
+        assert score == 1.0

--- a/tests/test_power_function.py
+++ b/tests/test_power_function.py
@@ -59,20 +59,6 @@ def test_power_function_score_function():
     config = PowerFunctionConfig(seed=42)
     dataset = PowerFunctionDataset(config)
 
-    item = dataset[0]
-
-    # Answer is within 1e-6 of solution
-    answer = str(item["metadata"]["solution"] - 1e-7)
-    assert dataset.score_answer(answer, item) == 1.0
-
-    # Answer is within 1e-1 of solution
-    answer = str(item["metadata"]["solution"] - 1e-2)
-    assert dataset.score_answer(answer, item) == 0.5
-
-    # Answer is far from solution
-    answer = str(item["metadata"]["solution"] - 1)
-    assert dataset.score_answer(answer, item) == 0.0
-
-    # Answer is None
-    answer = None
-    assert dataset.score_answer(answer, item) == 0.0
+    for item in dataset:
+        answer = item["answer"]
+        assert dataset.score_answer(answer, item) == 1.0


### PR DESCRIPTION
The following PR makes changes to the `gsm_symbolic`, `power_function` and `pool_matrix` datasets. Each dataset had issues in its implementation as recored in the eval [sheet](https://docs.google.com/spreadsheets/d/1qk2BgxzfRZzTzMQnclCr47ioykgltbGkMJUHO2sH6Gw/edit?gid=569441543#gid=569441543). 

- `pool_matrix` dataset did not specify precision of answers (i.e) 2 decimal places. Clarifying this along and answer function lead to more accurate assessment of models
- `gsm_symbolic` dataset had minor issues where answers occasionally included units in outputs. Adapted prompt to specify answers should not include units
- `power_function` - in its current implementation, for very small numbers `score_answer` will score as correct provided its below the tolerance threshold and thus is too lenient. For very large numbers current implementation`score_answer` is always 0 and is too harsh. The adjusted implementation tries to find a balance by ensuring the two answers are correct to 3 significant figures