### PR TITLE
Curriculum for basic_arithmetic

### DIFF
--- a/reasoning_gym/arithmetic/__init__.py
+++ b/reasoning_gym/arithmetic/__init__.py
@@ -2,7 +2,7 @@
 Arithmetic tasks for training reasoning capabilities:
 """
 
-from .basic_arithmetic import BasicArithmeticDataset, BasicArithmeticDatasetConfig
+from .basic_arithmetic import BasicArithmeticCurriculum, BasicArithmeticDataset, BasicArithmeticDatasetConfig
 from .bitwise_arithmetic import BitwiseArithmeticConfig, BitwiseArithmeticDataset
 from .calendar_arithmetic import CalendarArithmeticConfig, CalendarArithmeticDataset
 from .chain_sum import ChainSumConfig, ChainSumDataset
@@ -24,6 +24,7 @@ from .time_intervals import TimeIntervalsConfig, TimeIntervalsDataset
 __all__ = [
     "BasicArithmeticDataset",
     "BasicArithmeticDatasetConfig",
+    "BasicArithmeticCurriculum",
     "ChainSumDataset",
     "ChainSumConfig",
     "CalendarArithmeticConfig",

--- a/reasoning_gym/arithmetic/basic_arithmetic.py
+++ b/reasoning_gym/arithmetic/basic_arithmetic.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from random import Random
 from typing import Any, Literal, Optional
 
-from ..coaching import AttributeType, BaseCurriculum, RangeAttributeDefinition, ScalarAttributeDefinition
+from ..coaching import AttributeType, BaseCurriculum, RangeAttributeDefinition
 from ..factory import ProceduralDataset, register_dataset
 
 

--- a/reasoning_gym/arithmetic/basic_arithmetic.py
+++ b/reasoning_gym/arithmetic/basic_arithmetic.py
@@ -259,8 +259,8 @@ class BasicArithmeticCurriculum(BaseCurriculum):
                 levels=[
                     [1, 2],
                     [1, 3],
-                    [1, 4],
-                    [1, 4],
+                    [2, 3],
+                    [2, 4],
                 ],
                 default_level=0,
                 description="Range of digits in each term",

--- a/reasoning_gym/arithmetic/basic_arithmetic.py
+++ b/reasoning_gym/arithmetic/basic_arithmetic.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from random import Random
 from typing import Any, Literal, Optional
 
+from ..coaching import AttributeType, BaseCurriculum, RangeAttributeDefinition, ScalarAttributeDefinition
 from ..factory import ProceduralDataset, register_dataset
 
 
@@ -231,6 +232,44 @@ class BasicArithmeticDataset(ProceduralDataset):
             templates = ["What is {0}?", "Solve {0}.", "Compute {0}.", "Evaluate: {0}."]
             template = rng.choice(templates)
             return template.format(expression)
+
+
+class BasicArithmeticCurriculum(BaseCurriculum):
+    def __init__(self):
+        super().__init__(BasicArithmeticCurriculum.__name__, BasicArithmeticDatasetConfig)
+
+        self._define_attributes(
+            RangeAttributeDefinition(
+                name="num_terms",
+                levels=[
+                    [2, 2],
+                    [3, 4],
+                    [4, 5],
+                    [5, 6],
+                ],
+                default_level=0,
+                description="Range of terms in the arithmetic expression",
+                attr_type=AttributeType.STATIC,
+                min_value=2,
+                lower_field_name="min_terms",
+                upper_field_name="max_terms",
+            ),
+            RangeAttributeDefinition(
+                name="num_digits",
+                levels=[
+                    [1, 2],
+                    [1, 3],
+                    [1, 4],
+                    [1, 4],
+                ],
+                default_level=0,
+                description="Range of digits in each term",
+                attr_type=AttributeType.STATIC,
+                min_value=1,
+                lower_field_name="min_digits",
+                upper_field_name="max_digits",
+            ),
+        )
 
 
 # Register the dataset

--- a/reasoning_gym/coaching/base_curriculum.py
+++ b/reasoning_gym/coaching/base_curriculum.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 from ..factory import ConfigT
 from .attributes import AttributeDefinition, RangeAttributeDefinition, ScalarAttributeDefinition

--- a/tests/test_basic_arithmetic.py
+++ b/tests/test_basic_arithmetic.py
@@ -1,6 +1,7 @@
 import pytest
 
 from reasoning_gym.arithmetic.basic_arithmetic import (
+    BasicArithmeticCurriculum,
     BasicArithmeticDataset,
     BasicArithmeticDatasetConfig,
     eval_floordiv,
@@ -96,3 +97,47 @@ def test_arithmetic_dataset_iteration():
     first_items = list(dataset)
     second_items = list(dataset)
     assert first_items == second_items, "Multiple iterations should yield same items"
+
+
+def test_curriculum():
+    """Teset basic arithmetic curriculum"""
+    curriculum = BasicArithmeticCurriculum()
+
+    base_value = {"size": 500, "seed": 42}
+
+    base_cfg = curriculum.generate_configuration(base_value)
+    # level 1
+
+    assert base_cfg.min_terms == 2
+    assert base_cfg.max_terms == 2
+    assert base_cfg.min_digits == 1
+    assert base_cfg.max_digits == 2
+    assert base_cfg.size == 500
+    assert base_cfg.seed == 42
+
+    # level 2
+    curriculum.increment_attr_level("num_terms")
+    curriculum.increment_attr_level("num_digits")
+    increased_cfg = curriculum.generate_configuration()
+    assert increased_cfg.min_terms == 3
+    assert increased_cfg.max_terms == 4
+    assert increased_cfg.min_digits == 1
+    assert increased_cfg.max_digits == 3
+
+    # level 3
+    curriculum.increment_attr_level("num_terms")
+    curriculum.increment_attr_level("num_digits")
+    increased_cfg = curriculum.generate_configuration()
+    assert increased_cfg.min_terms == 4
+    assert increased_cfg.max_terms == 5
+    assert increased_cfg.min_digits == 2
+    assert increased_cfg.max_digits == 3
+
+    # level 2
+    curriculum.decrement_attr_level("num_terms")
+    curriculum.decrement_attr_level("num_digits")
+    decreased_cfg = curriculum.generate_configuration()
+    assert decreased_cfg.min_terms == 3
+    assert decreased_cfg.max_terms == 4
+    assert decreased_cfg.min_digits == 1
+    assert decreased_cfg.max_digits == 3


### PR DESCRIPTION
Curriculum for basic_arithmetic. 

The levels are expressed like this [min_terms, max_terms, min_digits, max_digits].

Level 0: [2,2,1,2]
Level 1: [3,4,1,3]
Level 2: [4,5,1,4]
Level 3: [5,6,1,4]

The annoying thing is that you have to increment both the num_terms and num_digits pairs when moving between levels. 

```python
curriculum = BasicArithmeticCurriculum()

curriculum.set_attr_level("num_terms",0)
curriculum.set_attr_level("num_digits",0)
config = curriculum.generate_configuration()

dataset = BasicArithmeticDataset(config)

print("FIRST LEVEL(2 terms, 1-2 digits):")
print(dataset[0]['question'])


curriculum.increment_attr_level("num_terms")
curriculum.increment_attr_level("num_digits")

config = curriculum.generate_configuration()

dataset = BasicArithmeticDataset(config)

print("SECOND LEVEL(3-4 terms, 1-3 digits):")
print(dataset[0]['question'])
```
```bash
FIRST LEVEL(2 terms, 1-2 digits):
Calculate -78 * 3 * 96 * ( -44 - -46 ).
{'min_terms': 5, 'max_terms': 6, 'min_digits': 1, 'max_digits': 3}
SECOND LEVEL(3-4 terms, 1-3 digits):
Calculate ( 7 * 9 + 1 - -6 ) + -2 - -5.
```


It might be easier to override the generate_configurations by using the method below. We wouldn't do this if we want more flexibility with incrementing each of (num_terms, num_digits) individually. 
```python
class BasicArithmeticCurriculum(BaseCurriculum):
    def __init__(self):
        super().__init__(BasicArithmeticCurriculum.__name__, BasicArithmeticDatasetConfig)

        # Define a single attribute that controls both terms and digits
        self._define_attributes(
            AttributeDefinition(
                name="difficulty",
                levels=[
                    {"min_terms": 2, "max_terms": 2, "min_digits": 1, "max_digits": 2},  # Level 0
                    {"min_terms": 3, "max_terms": 4, "min_digits": 1, "max_digits": 3},  # Level 1
                    {"min_terms": 4, "max_terms": 5, "min_digits": 1, "max_digits": 4},  # Level 2
                    {"min_terms": 5, "max_terms": 6, "min_digits": 1, "max_digits": 4},  # Level 3
                ],
                default_level=0,
                description="Combined difficulty level controlling terms and digits",
                attr_type=AttributeType.STATIC,
            ),
        )
        
    def generate_configuration(self, defaults: Optional[dict[str, Any]] = None) -> BasicArithmeticDatasetConfig:
        """Override to handle the custom difficulty attribute"""
        config_args = defaults.copy() if defaults is not None else {}
        
        # Get the current difficulty level settings
        difficulty_settings = self.get_attr_value("difficulty")
        
        # Update config args with all settings from the difficulty level
        config_args.update(difficulty_settings)
        
        return self._config_cls(**config_args)
```
```python
curriculum = BasicArithmeticCurriculum()

curriculum.set_attr_level("difficulty",0)

config = curriculum.generate_configuration()
dataset = BasicArithmeticDataset(config)
print(dataset[0]['question'])

curriculum.increment_attr_level("difficulty")
config = curriculum.generate_configuration()
dataset = BasicArithmeticDataset(config)
print(dataset[0]['question'])
```
