### PR TITLE
Fix Rush Hour

### DIFF
--- a/reasoning_gym/games/rush_hour.py
+++ b/reasoning_gym/games/rush_hour.py
@@ -149,7 +149,8 @@ class RushHourDataset(ProceduralDataset):
         instructions = (
             "Move the red car (AA) to the exit on the right.\n"
             "Specify moves in the format: 'F+1 K+1 M-1 C+3 H+2 ...'\n"
-            "where the letter is the vehicle and +/- number is spaces to move right/left or down/up."
+            "where the letter is the vehicle and +/- number is spaces to move right/left or down/up.\n"
+            "A car oriented vertically can only move up and down, a car oriented horizontally can only move left and right."
         )
 
         return {
@@ -182,7 +183,7 @@ class RushHourDataset(ProceduralDataset):
             board.perform_moves(answer)
 
             # Check if solved
-            return 1.0 if board.solved else 0.0
+            return 1.0 if board.solved else 0.01
 
         except (ValueError, IndexError, AttributeError) as e:
             # Handle malformed input gracefully
@@ -326,9 +327,7 @@ class Board:
         move_ops = [(chars, int(num) if sign == "+" else -int(num)) for chars, sign, num in matches]
 
         for target, dir in move_ops:
-            print(target, dir)
             self.move(target, dir)
-            print(self.board_str())
 
     @property
     def solved(self) -> bool:

--- a/reasoning_gym/games/rush_hour.py
+++ b/reasoning_gym/games/rush_hour.py
@@ -150,6 +150,7 @@ class RushHourDataset(ProceduralDataset):
             "Move the red car (AA) to the exit on the right.\n"
             "Specify moves in the format: 'F+1 K+1 M-1 C+3 H+2 ...'\n"
             "where the letter is the vehicle and +/- number is spaces to move right/left or down/up.\n"
+            "Walls are marked with an 'x'. Cars cannot move through walls, and walls cannot be moved.\n"
             "A car oriented vertically can only move up and down, a car oriented horizontally can only move left and right."
         )
 

--- a/tests/test_rush_hour.py
+++ b/tests/test_rush_hour.py
@@ -73,11 +73,11 @@ def test_score_answer():
     # Test invalid answers
     assert dataset.score_answer(None, puzzle) == 0.0
     assert dataset.score_answer("", puzzle) == 0.0
-    assert dataset.score_answer("invalid", puzzle) == 0.0
-    assert dataset.score_answer("A+1 B-2 INVALID", puzzle) == 0.0
+    assert dataset.score_answer("invalid", puzzle) == 0.01
+    assert dataset.score_answer("A+1 B-2 INVALID", puzzle) == 0.01
 
     # Test incomplete solution
-    assert dataset.score_answer("A+1 B-2", puzzle) == 0.0
+    assert dataset.score_answer("A+1 B-2", puzzle) == 0.01
 
 
 def test_perform_moves():
@@ -86,14 +86,17 @@ def test_perform_moves():
     incomplete_moves = "F+1 K+1 M-1 C+3 H+2 J-1 E+1 G+3 B-1 I-1 A-3 I+1 L+1 B+3 I-1 A+2 G-3"
     b.perform_moves(incomplete_moves)
     assert not b.solved
+    incomplete_moves = "X+1 \n Y+22"
+    b.perform_moves(incomplete_moves)
+    assert not b.solved
     solution = "E-1 H-3 A-1 J+1 C-3 M+1 B+1 K-4 A+1 C+2 D-1 F-1 H+3 A-1 K+1 B-1 M-1 C+1 J-1 E+1 G+3 A-1 I+1 B-3 I-1 A+1 G-1 E-1 J+1 C-1 K-1 L-1 M+3 A+3"
     b.perform_moves(solution)
     assert b.solved
 
 
 def test_perform_moves_walls():
+    ## ?? This test is incomplete. I don't know why.
     b = Board("BBoIKxCCCIKoGAAJooGoHJDDooHEELoFFoxL")
-    print(b.board_str())
     # assert sum(1 for p in b._pieces if p.fixed) == 2, "two walls expected"
     # assert not b.solved
 

--- a/tests/test_rush_hour.py
+++ b/tests/test_rush_hour.py
@@ -30,7 +30,7 @@ def test_rush_hour_deterministic():
 
 def test_rush_hour_items():
     """Test basic properties of generated items"""
-    config = RushHourConfig(min_moves=1, max_moves=10, size=10, seed=42)
+    config = RushHourConfig(min_moves=1, max_moves=10, size=18000, seed=42)
     dataset = RushHourDataset(config)
 
     for i in range(len(dataset)):
@@ -82,6 +82,7 @@ def test_score_answer():
 
 def test_perform_moves():
     b = Board("GBBoLoGHIoLMGHIAAMCCCKoMooJKDDEEJFFo")
+
     assert not b.solved
     incomplete_moves = "F+1 K+1 M-1 C+3 H+2 J-1 E+1 G+3 B-1 I-1 A-3 I+1 L+1 B+3 I-1 A+2 G-3"
     b.perform_moves(incomplete_moves)


### PR DESCRIPTION
I _think_ this fixes Rush Hour? I don't have the full traces so don't know what actually caused the bug, but I'd wager it's trying to print bad boards. This PR also explains the game in the prompt. For instance, some games have walls but these were never previously explained.

This env has some problems, for instance there are these constants that should be config attributes:

BOARD_SIZE = 6
PRIMARY_ROW = 2
PRIMARY_SIZE = 2
MIN_PIECE_SIZE = 2
MAX_PIECE_SIZE = 3