### PR TITLE
Added Boxnet dataset and curriculum closes #209

### DIFF
--- a/reasoning_gym/games/__init__.py
+++ b/reasoning_gym/games/__init__.py
@@ -6,6 +6,7 @@ Game tasks for training reasoning capabilities:
 - Simulation games
 """
 
+from .boxnet import BoxnetConfig, BoxnetCurriculum, BoxnetDataset
 from .countdown import CountdownConfig, CountdownDataset
 from .emoji_mystery import EmojiMysteryConfig, EmojiMysteryCurriculum, EmojiMysteryDataset
 from .futoshiki import FutoshikiConfig, FutoshikiDataset
@@ -22,6 +23,9 @@ from .tower_of_hanoi import HanoiConfig, HanoiDataset
 from .tsumego import TsumegoConfig, TsumegoCurriculum, TsumegoDataset
 
 __all__ = [
+    "BoxnetConfig",
+    "BoxnetDataset",
+    "BoxnetCurriculum",
     "CountdownConfig",
     "CountdownDataset",
     "EmojiMysteryConfig",

--- a/reasoning_gym/games/boxnet.py
+++ b/reasoning_gym/games/boxnet.py
@@ -1,0 +1,254 @@
+import copy
+import json
+import random
+import re
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import numpy as np
+
+from ..coaching import AttributeType, BaseCurriculum, RangeAttributeDefinition
+from ..factory import ProceduralDataset, register_dataset
+
+BOXNET_PROMPT = """
+You are a central planner tasked with directing agents in a grid-like field to move colored boxes to their corresponding color-coded targets.
+Each agent occupies a 1x1 square and can only interact with objects within its square. Agents can move a box to an adjacent square or
+directly to a target square of the same color. A square may contain multiple boxes and targets. The squares are identified by their center
+coordinates (e.g., square[0.5, 0.5]). Actions are formatted as: move(box_color, destination), where box_color is the color of the box and
+destination is either a target of the same color or an adjacent square. Your objective is to create a sequence of action plans that instructs
+each agent to match all boxes to their color-coded targets in the most efficient manner.
+
+Please adhere to the following rules when specifying your action plan:
+1. Single Action per Agent: Assign only one action to each agent at a time. However, the final answer shoule be a list of action plans for multiple steps.
+2. Unique Agent Keys: Use unique keys for each agent in the JSON format action plan. The key should be the agent's coordinates in the format "Agent[x, y]".
+3. Prioritize Matching Boxes to Targets: Always prioritize actions that will match a box to its target over moving a box to an adjacent square.
+4. Sequential Action Planning: The whole returned answer should be a list of action plans for multiple steps, do not just return one step plan.
+5. Clear Formatting: Ensure the action plan is clearly formatted in JSON, with each agent's action specified as a key-value pair.
+6. Conflict Resolution: Ensure that no two agents are assigned actions that would interfere with each other.
+7. Optimize Efficiency: Aim to minimize the number of moves required to match all boxes with their targets.
+
+Here is the format for your action plan:
+Please provide your final answer as a list of action dictionaries.
+For example:
+```json
+[{"Agent[0.5, 0.5]":"move(box_blue, square[0.5, 1.5])", "Agent[1.5, 0.5]":"move(box_red, target_red)"}, {"Agent[0.5, 1.5]":"move(box_blue, target_blue)", "Agent[2.5, 0.5]":"move...}, {...}...]
+```
+Include an agent in the action plan only if it has a task to perform next.
+"""
+
+
+def action_from_response(pg_dict_input, original_response_dict_list):
+    pg_dict_current = copy.deepcopy(pg_dict_input)
+
+    for original_response_dict in original_response_dict_list:
+        transformed_dict = {}
+        for key, value in original_response_dict.items():
+            coordinates = tuple(map(float, re.findall(r"\d+\.?\d*", key)))
+            match = re.match(r"move\((.*?),\s(.*?)\)", value)
+            if match:
+                item, location = match.groups()
+                if "square" in location:
+                    location = tuple(map(float, re.findall(r"\d+\.?\d*", location)))
+                transformed_dict[coordinates] = [item, location]
+
+        # Process each move with the current state
+        for key, value in transformed_dict.items():
+            current_pos = f"{key[0]}_{key[1]}"
+
+            # Check if this is a box-target matching move
+            if (
+                value[0] in pg_dict_current[current_pos]
+                and isinstance(value[1], str)
+                and value[1] in pg_dict_current[current_pos]
+                and value[0].startswith("box_")
+                and value[1].startswith("target_")
+                and value[0][4:] == value[1][7:]
+            ):
+                # Remove both box and target when matched
+                pg_dict_current[current_pos].remove(value[0])
+                pg_dict_current[current_pos].remove(value[1])
+
+            # Check if this is a movement to another square
+            elif value[0] in pg_dict_current[current_pos] and isinstance(
+                value[1], tuple
+            ):  # Only check coordinates for square movements
+                # Calculate if move is to adjacent square
+                if (np.abs(key[0] - value[1][0]) == 0 and np.abs(key[1] - value[1][1]) == 1) or (
+                    np.abs(key[0] - value[1][0]) == 1 and np.abs(key[1] - value[1][1]) == 0
+                ):
+                    # Move box to new location
+                    target_pos = f"{value[1][0]}_{value[1][1]}"
+                    pg_dict_current[current_pos].remove(value[0])
+                    pg_dict_current[target_pos].append(value[0])
+    return pg_dict_current
+
+
+@dataclass
+class BoxnetConfig:
+    """Configuration for Boxnet task generation"""
+
+    min_row_num: int = 1
+    max_row_num: int = 4
+    min_column_num: int = 2
+    max_column_num: int = 4
+    min_box_num: int = 1
+    max_box_num: int = 1
+    colour_list: list[str] = field(default_factory=lambda: ["red", "blue", "green"])
+    seed: Optional[int] = None
+    size: int = 500
+
+    def validate(self) -> None:
+        """Validate configuration parameters"""
+        assert self.size > 0, "size must be greater than 0"
+        assert self.min_row_num > 0, "min_row_num must be greater than 0"
+        assert self.max_row_num > 0, "max_row_num must be greater than 0"
+        assert self.min_column_num > 0, "min_column_num must be greater than 0"
+        assert self.max_column_num > 0, "max_column_num must be greater than 0"
+        assert self.min_box_num > 0, "min_box_num must be greater than 0"
+        assert self.max_box_num > 0, "max_box_num must be greater than 0"
+        assert self.min_box_num <= self.max_box_num, "min_box_num must be less than or equal to max_box_num"
+
+
+class BoxnetDataset(ProceduralDataset):
+    def __init__(self, config: BoxnetConfig):
+        super().__init__(config=config, seed=config.seed, size=config.size)
+
+    def __getitem__(self, idx: int) -> dict:
+        rng = random.Random(self.seed + idx)
+        row_num = rng.randint(self.config.min_row_num, self.config.max_row_num)
+        column_num = rng.randint(self.config.min_column_num, self.config.max_column_num)
+        pg_dict = self._generate_boxnet(rng, row_num, column_num, self.config.colour_list)
+        pg_dict_initial = copy.deepcopy(pg_dict)
+
+        state_update_prompt = self.state_update_func(row_num, column_num, pg_dict_initial)
+        question = BOXNET_PROMPT + "\n\n" + "The current left boxes and agents are: " + state_update_prompt + "\n"
+        return {
+            "question": question,
+            "answer": None,
+            "metadata": {
+                "difficulty": {
+                    "row_num": row_num,
+                    "column_num": column_num,
+                },
+                "initial_state": pg_dict,
+            },
+        }
+
+    def _generate_boxnet(self, rng: random.Random, row_num: int, column_num: int, colour_list: list[str]):
+        """Generate a Boxnet task"""
+        pg_dict = {}
+        for i in range(row_num):
+            for j in range(column_num):
+                pg_dict[str(i + 0.5) + "_" + str(j + 0.5)] = []
+
+        for colour in colour_list:
+            box_num = rng.randint(self.config.min_box_num, self.config.max_box_num)
+            for _ in range(box_num):
+                N_box = rng.randint(0, row_num * column_num - 1)
+                a_box = N_box // column_num
+                b_box = N_box % column_num
+                N_target = rng.randint(0, row_num * column_num - 1)
+                a_target = N_target // column_num
+                b_target = N_target % column_num
+                pg_dict[str(a_box + 0.5) + "_" + str(b_box + 0.5)].append("box_" + colour)
+                pg_dict[str(a_target + 0.5) + "_" + str(b_target + 0.5)].append("target_" + colour)
+        return pg_dict
+
+    def surround_index_func(self, row_num, coloum_num, row_index, coloum_index):
+        surround_index_list = []
+        for i, j in (
+            [row_index - 1, coloum_index],
+            [row_index + 1, coloum_index],
+            [row_index, coloum_index - 1],
+            [row_index, coloum_index + 1],
+        ):
+            if (
+                i >= 0
+                and i <= row_num - 1
+                and j >= 0
+                and j <= coloum_num - 1
+                and not (i == row_index and j == coloum_index)
+            ):
+                surround_index_list.append([i + 0.5, j + 0.5])
+        return surround_index_list
+
+    def state_update_func(self, pg_row_num, pg_column_num, pg_dict):
+        state_update_prompt = ""
+        for i in range(pg_row_num):
+            for j in range(pg_column_num):
+                square_item_list = pg_dict[str(i + 0.5) + "_" + str(j + 0.5)]
+                square_item_only_box = [item for item in square_item_list if item[:3] == "box"]
+                surround_index_list = self.surround_index_func(pg_row_num, pg_column_num, i, j)
+                state_update_prompt += f"Agent[{i+0.5}, {j+0.5}]: I am in square[{i+0.5}, {j+0.5}], I can observe {square_item_list}, I can do "
+                action_list = []
+                for box in square_item_only_box:
+                    for surround_index in surround_index_list:
+                        action_list.append(f"move({box}, square{surround_index})")
+                    if "target" + box[3:] in square_item_list:
+                        action_list.append(f"move({box}, target{box[3:]})")
+                state_update_prompt += f"{action_list}\n"
+        return state_update_prompt
+
+    def score_answer(self, answer: str | None, entry: dict[str, Any]) -> float:
+        reward = 0.0
+        if answer is not None:
+            try:
+                answer_dict = json.loads(answer)
+            except:
+                return 0.01
+            pg_dict_returned = action_from_response(entry["metadata"]["initial_state"], answer_dict)
+
+            initial_boxes = 0
+            for items in entry["metadata"]["initial_state"].values():
+                initial_boxes += sum(1 for item in items if item.startswith("box_"))
+
+            remaining_boxes = 0
+            for items in pg_dict_returned.values():
+                remaining_boxes += sum(1 for item in items if item.startswith("box_"))
+
+            lifted_ratio = (initial_boxes - remaining_boxes) / initial_boxes
+            reward = max(0.05, lifted_ratio)
+
+        return reward
+
+
+class BoxnetCurriculum(BaseCurriculum):
+    """Curriculum for Boxnet"""
+
+    def __init__(self):
+        super().__init__(BoxnetCurriculum.__name__, BoxnetConfig)
+        self._define_attributes(
+            RangeAttributeDefinition(
+                name="row_num",
+                description="The maximum number of rows in the grid",
+                lower_field_name="min_row_num",
+                upper_field_name="max_row_num",
+                min_value=1,
+                levels=list(range(1, 10)),
+                default_level=1,
+                attr_type=AttributeType.APPEND,
+            ),
+            RangeAttributeDefinition(
+                name="column_num",
+                description="The maximum number of columns in the grid",
+                lower_field_name="min_column_num",
+                upper_field_name="max_column_num",
+                min_value=1,
+                levels=list(range(1, 10)),
+                default_level=1,
+                attr_type=AttributeType.APPEND,
+            ),
+            RangeAttributeDefinition(
+                name="box_num",
+                description="The maximum number of boxes in the grid",
+                lower_field_name="min_box_num",
+                upper_field_name="max_box_num",
+                min_value=1,
+                levels=list(range(1, 10)),
+                default_level=1,
+                attr_type=AttributeType.APPEND,
+            ),
+        )
+
+
+register_dataset("boxnet", BoxnetDataset, BoxnetConfig, BoxnetCurriculum)

--- a/tests/test_boxnet.py
+++ b/tests/test_boxnet.py
@@ -1,0 +1,199 @@
+import pytest
+
+from reasoning_gym.games import BoxnetConfig, BoxnetCurriculum, BoxnetDataset
+from reasoning_gym.games.boxnet import action_from_response
+
+
+def test_boxnet_config_validation():
+    """Test that invalid configs raise appropriate errors"""
+    with pytest.raises(AssertionError):
+        config = BoxnetConfig(min_row_num=0)
+        config.validate()
+
+    with pytest.raises(AssertionError):
+        config = BoxnetConfig(min_box_num=0)
+        config.validate()
+
+
+def test_boxnet_deterministic():
+    """Test that dataset generates same items with same seed"""
+    config = BoxnetConfig(seed=42, size=10)
+    dataset1 = BoxnetDataset(config)
+    dataset2 = BoxnetDataset(config)
+
+    for i in range(len(dataset1)):
+        assert dataset1[i]["question"] == dataset2[i]["question"]
+        assert dataset1[i]["metadata"] == dataset2[i]["metadata"]
+
+
+def test_boxnet_items():
+    """Test basic properties of generated items"""
+    config = BoxnetConfig(
+        min_row_num=1, max_row_num=2, min_column_num=1, max_column_num=2, min_box_num=1, max_box_num=2, size=10, seed=42
+    )
+    dataset = BoxnetDataset(config)
+
+    for i in range(len(dataset)):
+        item = dataset[i]
+        assert isinstance(item, dict)
+        assert "question" in item
+        assert "answer" is None or "answer" in item
+        assert "metadata" in item
+        assert "difficulty" in item["metadata"]
+        assert "initial_state" in item["metadata"]
+
+        # Verify row_num and column_num are within limits
+        row_num = item["metadata"]["difficulty"]["row_num"]
+        column_num = item["metadata"]["difficulty"]["column_num"]
+        assert 1 <= row_num <= 2, f"row_num {row_num} outside valid range"
+        assert 1 <= column_num <= 2, f"column_num {column_num} outside valid range"
+
+        # Verify the state format
+        initial_state = item["metadata"]["initial_state"]
+        for key, value in initial_state.items():
+            assert "_" in key, f"Invalid grid key format: {key}"
+            assert isinstance(value, list), f"Grid value must be a list"
+            # Check that box and target color name formats are correct
+            for item_val in value:
+                if item_val.startswith("box_"):
+                    assert item_val[4:] in config.colour_list, f"Invalid box color: {item_val}"
+                elif item_val.startswith("target_"):
+                    assert item_val[7:] in config.colour_list, f"Invalid target color: {item_val}"
+
+
+def test_boxnet_grid_sizes():
+    """Test that generated grid respects row and column constraints"""
+    config = BoxnetConfig(
+        min_row_num=2,
+        max_row_num=3,
+        min_column_num=3,
+        max_column_num=4,
+        size=20,
+        seed=42,
+    )
+    dataset = BoxnetDataset(config)
+
+    rows_set = set()
+    columns_set = set()
+
+    for i in range(len(dataset)):
+        item = dataset[i]
+        row_num = item["metadata"]["difficulty"]["row_num"]
+        column_num = item["metadata"]["difficulty"]["column_num"]
+
+        rows_set.add(row_num)
+        columns_set.add(column_num)
+
+        # Verify grid dimensions in the state dictionary
+        initial_state = item["metadata"]["initial_state"]
+        grid_coords = set()
+        for key in initial_state.keys():
+            x, y = map(float, key.split("_"))
+            grid_coords.add((x, y))
+
+        # Check if the grid dimensions match the expected size
+        unique_x = set(x for x, _ in grid_coords)
+        unique_y = set(y for _, y in grid_coords)
+        assert len(unique_x) == row_num, f"Expected {row_num} rows, got {len(unique_x)}"
+        assert len(unique_y) == column_num, f"Expected {column_num} columns, got {len(unique_y)}"
+
+    # With enough samples, we should see variation in grid sizes
+    assert len(rows_set) > 1, "Expected variation in row numbers"
+    assert len(columns_set) > 1, "Expected variation in column numbers"
+
+
+def test_boxnet_box_distribution():
+    """Test that boxes and targets are distributed according to configuration"""
+    config = BoxnetConfig(
+        min_box_num=1,
+        max_box_num=2,
+        colour_list=["red", "blue"],
+        size=20,
+        seed=43,
+    )
+    dataset = BoxnetDataset(config)
+
+    for i in range(len(dataset)):
+        item = dataset[i]
+        initial_state = item["metadata"]["initial_state"]
+
+        # Count boxes and targets by color
+        boxes_count = {color: 0 for color in config.colour_list}
+        targets_count = {color: 0 for color in config.colour_list}
+
+        for cell_items in initial_state.values():
+            for item_val in cell_items:
+                if item_val.startswith("box_"):
+                    color = item_val[4:]
+                    boxes_count[color] += 1
+                elif item_val.startswith("target_"):
+                    color = item_val[7:]
+                    targets_count[color] += 1
+
+        # Verify each color has between min_box_num and max_box_num boxes
+        for color in config.colour_list:
+            assert (
+                config.min_box_num <= boxes_count[color] <= config.max_box_num
+            ), f"Color {color} has {boxes_count[color]} boxes, expected between {config.min_box_num} and {config.max_box_num}"
+
+            # Verify the number of targets matches the number of boxes for each color
+            assert (
+                boxes_count[color] == targets_count[color]
+            ), f"Color {color} has {boxes_count[color]} boxes but {targets_count[color]} targets"
+
+
+def test_boxnet_iteration():
+    """Test that iteration respects dataset size"""
+    config = BoxnetConfig(size=5, seed=42)  # Small size for testing
+    dataset = BoxnetDataset(config)
+
+    # Test manual iteration
+    items = []
+    for item in dataset:
+        items.append(item)
+    assert len(items) == config.size, "Iterator should yield exactly size items"
+
+    # Test list conversion
+    items = list(dataset)
+    assert len(items) == config.size, "Iterator should yield exactly size items"
+
+    # Test multiple iterations
+    first_items = list(dataset)
+    second_items = list(dataset)
+    assert len(first_items) == len(second_items), "Multiple iterations should yield same number of items"
+    for i in range(len(first_items)):
+        assert first_items[i]["question"] == second_items[i]["question"]
+        assert first_items[i]["metadata"] == second_items[i]["metadata"]
+
+
+def test_boxnet_curriculum():
+    """Test BoxnetCurriculum functionality"""
+    curriculum = BoxnetCurriculum()
+
+    base_value = {"size": 150, "seed": 1}
+
+    # Test initial configuration
+    base_cfg = curriculum.generate_configuration(base_value)
+    assert base_cfg.seed == 1
+    assert base_cfg.size == 150
+    assert base_cfg.min_row_num == 1 and base_cfg.max_row_num == 2
+    assert base_cfg.min_column_num == 1 and base_cfg.max_column_num == 2
+    assert base_cfg.min_box_num == 1 and base_cfg.max_box_num == 2
+
+    # Test incrementing attribute levels
+    curriculum.increment_attr_level("row_num")
+    curriculum.increment_attr_level("box_num")
+
+    increased_cfg = curriculum.generate_configuration(base_value)
+    assert increased_cfg.min_row_num == 1 and increased_cfg.max_row_num == 3
+    assert increased_cfg.min_box_num == 1 and increased_cfg.max_box_num == 3
+    # Column number should remain unchanged
+    assert increased_cfg.min_column_num == 1 and increased_cfg.max_column_num == 2
+
+    # Test decrementing attribute level
+    curriculum.decrement_attr_level("box_num")
+
+    partially_decreased_cfg = curriculum.generate_configuration(base_value)
+    assert partially_decreased_cfg.min_box_num == 1 and partially_decreased_cfg.max_box_num == 2
+    # Row number should remain at the increased level
+    assert partially_decreased_cfg.min_row_num == 1 and partially_decreased_cfg.max_row_num == 3


### PR DESCRIPTION
This PR adds the Boxnet dataset generator originally from the CodeSteer [paper](https://arxiv.org/abs/2502.04350). In the PR the CodeSteer generator is ported to reasoning-gym to the use the standard reasoning-gym interface.

**Files Changed**
- `reasoning_gym/games/boxnet.py` - Here we define `BoxNetConfig`, `BoxnetDataset` and BoxNetCurriculum` objects
- `tests/test_boxnet.py` - add unit tests for the Boxnet dataset and curriculum. 
