### PR TITLE
feat(env): Figlet Font Curriculum

### DIFF
--- a/reasoning_gym/cognition/__init__.py
+++ b/reasoning_gym/cognition/__init__.py
@@ -3,7 +3,7 @@ Cognition tasks for training reasoning capabilities.
 """
 
 from .color_cube_rotation import ColorCubeRotationConfig, ColorCubeRotationCurriculum, ColorCubeRotationDataset
-from .figlet_fonts import FigletFontConfig, FigletFontDataset
+from .figlet_fonts import FigletFontConfig, FigletFontCurriculum, FigletFontDataset
 from .modulo_grid import ModuloGridConfig, ModuloGridDataset
 from .needle_haystack import NeedleHaystackConfig, NeedleHaystackCurriculum, NeedleHaystackDataset
 from .number_sequences import NumberSequenceConfig, NumberSequenceCurriculum, NumberSequenceDataset
@@ -16,6 +16,7 @@ __all__ = [
     "ColorCubeRotationCurriculum",
     "FigletFontConfig",
     "FigletFontDataset",
+    "FigletFontCurriculum",
     "NumberSequenceConfig",
     "NumberSequenceDataset",
     "NumberSequenceCurriculum",

--- a/reasoning_gym/cognition/figlet_fonts.py
+++ b/reasoning_gym/cognition/figlet_fonts.py
@@ -185,7 +185,11 @@ class FigletFontDataset(ProceduralDataset):
         return {
             "question": rng.choice(self._prompt_templates).format(figlet_render=figlet_render),
             "answer": word,
-            "metadata": {"font": chosen_font, "space_letters": self.config.space_letters},
+            "metadata": {
+                "font": chosen_font,
+                "space_letters": self.config.space_letters,
+                "difficulty": {"word_len": len(word)},
+            },
         }
 
     def score_answer(self, answer: Optional[str], entry: dict[str, Any]) -> float:


### PR DESCRIPTION
Created a curriculum based on word len. For this purpose added 2 new parameters `min_word_len` and `max_word_len`. 

And since previously we were using the list of wordle words (which are all 5 letters), I updated it to read from the anagrams list. Not the optimal choice, but the library at least had sufficiently large amount of words with varying sizes. Perhaps at some point we'd want an english dictionary list of words in the library. 