### PR TITLE
fix: add score_answer() to number_sorting

### DIFF
--- a/reasoning_gym/algorithmic/number_sorting.py
+++ b/reasoning_gym/algorithmic/number_sorting.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from random import Random
-from typing import Optional
+from typing import Optional, Any
 
 from ..coaching import BaseCurriculum, RangeAttributeDefinition
 from ..factory import ProceduralDataset, register_dataset
@@ -99,6 +99,59 @@ Please follow the instruction below:
                 },
             },
         }
+
+    def score_answer(self, answer: Optional[str], entry: dict[str, Any]) -> float:
+        """Score the user's answer against the expected answer.
+
+        Args:
+            answer (Optional[str]): The user's answer string.
+            entry (dict[str, Any]): The original dataset entry with the correct answer.
+
+        Returns:
+            float: 1.0 for a correct answer, 0.0 for incorrect.
+        """
+        if answer is None:
+            return 0.0
+
+        try:
+            # Try to parse the user's answer as a list of strings
+            user_answer = eval(answer)
+            if not isinstance(user_answer, list):
+                return 0.0
+
+            # Get the expected answer
+            expected_answer = eval(entry["answer"])
+
+            # Check if the lists have the same length
+            if len(user_answer) != len(expected_answer):
+                return 0.0
+
+            # Convert both answers to floats for comparison
+            user_floats = [float(num) for num in user_answer]
+            expected_floats = [float(num) for num in expected_answer]
+
+            # First, verify the user's answer is properly sorted
+            direction = entry["metadata"]["direction"]
+            is_correctly_sorted = False
+
+            if direction == "ascending":
+                is_correctly_sorted = user_floats == sorted(user_floats)
+            else:  # descending
+                is_correctly_sorted = user_floats == sorted(user_floats, reverse=True)
+
+            if not is_correctly_sorted:
+                return 0.0
+
+            # Check if the values are close enough (allowing for small rounding differences)
+            tolerance = 0.1  # Increased tolerance to handle decimal differences
+            for i in range(len(user_floats)):
+                if abs(user_floats[i] - expected_floats[i]) > tolerance:
+                    return 0.0
+
+            return 1.0
+        except Exception as e:
+            # Any parsing error means the answer is incorrect
+            return 0.0
 
 
 class NumberSortingCurriculum(BaseCurriculum):


### PR DESCRIPTION
This pull request addresses https://github.com/open-thought/reasoning-gym/issues/377 and introduces a new method for scoring answers in the `NumberSortingDataset` and adds corresponding tests to validate its functionality. The key changes include the addition of the `score_answer` method and a new test function to ensure the method works correctly.

### New functionality:
* [`reasoning_gym/algorithmic/number_sorting.py`](diffhunk://#diff-39765fa4df0b9c536903eefb5a735d3bf4e95b1612031d3dec0a93ed6d5b4c93R103-R155): Added the `score_answer` method to evaluate user answers against the expected answers, including checks for correct sorting and numerical tolerance.

### Testing:
* [`tests/test_number_sorting.py`](diffhunk://#diff-f14aeb99d85f8b6aac3bdd7fcf9b3339f6e0c3228c0e56ebd3783e52c11c8d61R120-R175): Added a new `test_number_sorting_score_answer` function to validate various scenarios for the `score_answer` method, ensuring it correctly identifies correct and incorrect answers.

### Minor changes:
* [`reasoning_gym/algorithmic/number_sorting.py`](diffhunk://#diff-39765fa4df0b9c536903eefb5a735d3bf4e95b1612031d3dec0a93ed6d5b4c93L5-R5): Updated imports to include `Any` from the `typing` module.