### PR TITLE
Fix small bit of old code

### DIFF
--- a/reasoning_gym/logic/contrib/logic_puzzle/clues.py
+++ b/reasoning_gym/logic/contrib/logic_puzzle/clues.py
@@ -210,7 +210,7 @@ class right_of(Clue):
     houses: tuple[int, ...] = field(default_factory=lambda: (1, 2, 3, 4, 5))
 
     def as_cnf(self) -> list[tuple[str]]:
-        return sat_utils.from_dnf(
+        return from_dnf(
             (comb(self.value1, i), comb(self.value2, j)) for i, j in product(self.houses, self.houses) if i > j
         )
 


### PR DESCRIPTION
Removed the `sat_utils.` that was left there from the original zebra package.

This allows the zebra generator to be used with the full set of available clues.