### PR TITLE
fix(training): Prepend `<think>` token in format reward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ htmlcov/
 # Jupyter Notebook
 .ipynb_checkpoints/
 .virtual_documents/
+
+# logs
+wandb/
+outputs/
+*.log

--- a/training/configs/llama3.1_1b_grpo.yaml
+++ b/training/configs/llama3.1_1b_grpo.yaml
@@ -35,6 +35,7 @@ reward:
   format_reward:
     enable: True
     scaling_factor: 0.2
+    prepend_think_token: False  # Set to True only when the tokenizer's prompt template pre-fills the generation with <think>, such as in the case of (distilled) r1 models
   length_reward:
     enable: True
     scaling_factor: 0.2

--- a/training/configs/llama3.1_1b_grpo.yaml
+++ b/training/configs/llama3.1_1b_grpo.yaml
@@ -76,6 +76,8 @@ actor_rollout_ref:
     ppo_epochs: 1
     shuffle: False
     ulysses_sequence_parallel_size: 1 # sp size
+    checkpoint:
+      contents: ['model', 'hf_model', 'optimizer', 'extra']
     optim:
       lr: 1e-6
       lr_warmup_steps_ratio: 0.  # the total steps will be injected during runtime

--- a/training/configs/qwen2.5_1.5b_grpo.yaml
+++ b/training/configs/qwen2.5_1.5b_grpo.yaml
@@ -35,6 +35,7 @@ reward:
   format_reward:
     enable: True
     scaling_factor: 0.2
+    prepend_think_token: False  # Set to True only when the tokenizer's prompt template pre-fills the generation with <think>, such as in the case of (distilled) r1 models
   length_reward:
     enable: True
     scaling_factor: 0.2
@@ -116,6 +117,8 @@ actor_rollout_ref:
     tensor_model_parallel_size: 2
     max_num_batched_tokens: 8192
     max_num_seqs: 1024
+    max_model_len: 32768
+    max_num_batched_tokens: 32768
     log_prob_micro_batch_size: null # will be deprecated, use log_prob_micro_batch_size_per_gpu
     log_prob_micro_batch_size_per_gpu: 160
     log_prob_use_dynamic_bsz: ${actor_rollout_ref.actor.use_dynamic_bsz}

--- a/training/configs/qwen2.5_1.5b_grpo.yaml
+++ b/training/configs/qwen2.5_1.5b_grpo.yaml
@@ -117,8 +117,7 @@ actor_rollout_ref:
     tensor_model_parallel_size: 2
     max_num_batched_tokens: 8192
     max_num_seqs: 1024
-    max_model_len: 32768
-    max_num_batched_tokens: 32768
+    max_model_len: 1024
     log_prob_micro_batch_size: null # will be deprecated, use log_prob_micro_batch_size_per_gpu
     log_prob_micro_batch_size_per_gpu: 160
     log_prob_use_dynamic_bsz: ${actor_rollout_ref.actor.use_dynamic_bsz}
@@ -147,7 +146,7 @@ trainer:
   total_epochs: 10
   total_training_steps: null
   project_name: rg-test
-  experiment_name: verl_grpo_llama3.1_1b
+  experiment_name: verl_grpo_qwen2.5_1.5b
   logger: [ 'console', 'wandb' ]
   val_generations_to_log_to_wandb: 0
   nnodes: 1

--- a/training/configs/qwen2.5_1.5b_grpo.yaml
+++ b/training/configs/qwen2.5_1.5b_grpo.yaml
@@ -76,6 +76,8 @@ actor_rollout_ref:
     ppo_epochs: 1
     shuffle: False
     ulysses_sequence_parallel_size: 1 # sp size
+    checkpoint:
+      contents: ['model', 'hf_model', 'optimizer', 'extra']
     optim:
       lr: 1e-6
       lr_warmup_steps_ratio: 0.  # the total steps will be injected during runtime

--- a/training/trainers/ray_grpo_trainer.py
+++ b/training/trainers/ray_grpo_trainer.py
@@ -31,6 +31,7 @@ class RayGRPOTrainer(RayPPOTrainer):
         self.max_output_length = max_output_length
 
         self.format_reward_scaling_factor = config.reward.format_reward.scaling_factor
+        self.format_reward_prepend_think_token = config.reward.format_reward.prepend_think_token
         self.length_reward_scaling_factor = config.reward.length_reward.scaling_factor
 
         train_reward_fn = lambda data: self._score_output(data, num_examine=0)
@@ -99,6 +100,8 @@ class RayGRPOTrainer(RayPPOTrainer):
 
     def _compute_format_reward(self, solution_str: str) -> float:
         """Reward use of exactly one correctly structured <think> and <answer> block."""
+        if self.format_reward_prepend_think_token:
+            solution_str = "<think>" + solution_str
         scaling_factor = self.format_reward_scaling_factor
         # check <think> and <answer> blocks are present
         pattern = r"\s*<think>.*?</think>\s*<answer>.*?</answer>"


### PR DESCRIPTION
(Distilled) r1 models prepend the <think> token during tokenizing the prompt, hence why this is not visible in the final output that we evaluate. 

For this reason, I introduce a new parameter in the config called `prepend_think_token`, whose function is self-explanatory.

It should work, see below (first sample doesn't format correctly, second one does and gets format reward)

```
reward=0.0 (score=0.0, format=0.0, length=0.0), seq=<｜begin▁of▁sentence｜>A conversation between User and Assistant. The user asks a question, and the Assistant solves it.
The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., <think> reasoning process here </think>
<answer>answer here</answer>
Do not explain your reasoning inside the answer tags, provide only the final answer. When an example is provided, you should strictly follow the format of the output/answer in that example.
<｜User｜>Two strings are isomorphic if the characters in one string can be replaced to get the second string.

All occurrences of a character must be replaced with another character while preserving the order of characters.

No two characters may map to the same character, but a character may map to itself.

Return True if the following two strings are isomorphic, or False otherwise:
skjfrfcqp jfhwdmvie
<｜Assistant｜><think>
Okay, let me analyze this problem step by step. We have two strings, and we need to determine if they are isomorphic. An isomorphic pair means that each character in one string can be replaced by a unique character from the other string, and the order of characters remains the same.

First, I should make sure I understand the problem correctly. If the two strings are isomorphic, every occurrence of a character in the first string must map to exactly one character in the second string, and vice versa. Importantly, two different characters in the first string shouldn't map to the same character in the second string, and each character in the second string must be mapped from exactly one character in the first string.

Now, looking at the specific example given: the strings are "skjfrfcqp" and "jfhwdmvie". I notice that the lengths of both strings are the same, which is a good start because isomorphic strings must be of equal length.

Next, I need to check each character in the first string against the corresponding character in the second string to see if there is a consistent mapping without any conflicts.

Let me go through each character one by one:

1. The first character of the first string is 's', and the corresponding character in the second string is 'j'. This suggests that 's' maps to 'j'.
2. The second character in the first string is 'k', and in the second string, it's 'f'. So, 'k' maps to 'f'.
3. Continue this process to map all characters in the first string to the second string.

I'll create a dictionary in my mind to keep track of these mappings. Each time I find a new character in the first string that hasn't been mapped yet, I assign it the next available character from the second string.

However, I realized that I should also check for any mismatches in the mappings. For example, if at any point a character from the first string maps to a different character than the one I previously assigned, the strings are not isomorphic.

Looking at the example again, I'll write out the mappings:

- s → j
- k → f
- j → h
- f → w
- r → d
- f → m (Wait, wait, no, in the second string it's 'jfhwdmvie', so let's see each position.
4. The third character in the first string is 'j' with 'h' in the second string. So, j → h.
5. Next, first string 'f' → second string 'w'.
6. Third string's 'r' → second string 'd'.
7. Fourth string's 'f' → second string 'm'.
8. Fifth string's 'c' → second string 'v'.
9. Sixth string's 'q' → second string 'i'.
10. Seventh string's 'p' → second string 'e'.

So, the mappings are:

s → j

k → f

j → h

f → w

r → d

m → ? Hmm, wait a second. Because m is another character. Let me check if 'm' in the first string maps to 'm' in the second string, but 'm' is a unique character in the first string, so if the mapping goes 'm' → 'm', that would be acceptable. But in this particular case, I need to ensure that all the mappings are consistent.

Wait, I'm getting confused. Let me clarify: each character in the first string must map to a unique character in the second string, and each character in the second string must have a unique map from the first string.

Now, looking at the second string, is there any duplicate mappings?

For example, does the first string have two different characters that map to the same character in the second string? If the second string has 'jfhwdmvie', each character is unique. So, the mappings are also unique between<｜end▁of▁sentence｜>
/home/zafstojano/miniconda3/envs/torch/lib/python3.11/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
step:1 - global_seqlen/min:56536.000 - global_seqlen/max:58216.000 - global_seqlen/minmax_diff:1680.000 - global_seqlen/balanced_min:57376.000 - global_seqlen/balanced_max:57376.000 - global_seqlen/mean:57376.000 - actor/kl_loss:0.001 - actor/kl_coef:0.001 - actor/entropy_loss:0.784 - actor/pg_loss:0.060 - actor/pg_clipfrac:0.000 - actor/ppo_kl:0.000 - actor/grad_norm:0.334 - perf/mfu/actor:0.000 - perf/max_memory_allocated_gb:33.460 - perf/max_memory_reserved_gb:34.564 - perf/cpu_memory_used_gb:61.268 - actor/lr:0.000 - critic/score/mean:0.422 - critic/score/max:2.000 - critic/score/min:0.000 - critic/rewards/mean:0.422 - critic/rewards/max:2.000 - critic/rewards/min:0.000 - critic/advantages/mean:-0.106 - critic/advantages/max:2.475 - critic/advantages/min:-1.323 - critic/returns/mean:-0.106 - critic/returns/max:2.475 - critic/returns/min:-1.323 - response_length/mean:695.312 - response_length/max:829.000 - response_length/min:177.000 - response_length/clip_ratio:0.000 - prompt_length/mean:201.188 - prompt_length/max:205.000 - prompt_length/min:197.000 - prompt_length/clip_ratio:0.000 - timing_s/gen:20.656 - timing_s/old_log_prob:3.888 - timing_s/ref:5.268 - timing_s/adv:0.075 - timing_s/update_actor:13.457 - timing_s/step:43.348 - timing_per_token_ms/gen:0.232 - timing_per_token_ms/adv:0.001 - timing_per_token_ms/ref:0.046 - timing_per_token_ms/update_actor:0.117 - perf/total_num_tokens:114752.000 - perf/time_per_step:43.348 - perf/throughput:1323.601

Training Progress:   0%|          | 1/625 [00:43<7:31:16, 43.39s/it]
/home/zafstojano/miniconda3/envs/torch/lib/python3.11/site-packages/torch/utils/checkpoint.py:1399: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with device_autocast_ctx, torch.cpu.amp.autocast(**cpu_autocast_kwargs), recompute_context:  # type: ignore[attr-defined]
reward=1.0 (score=0.0, format=1.0, length=0.0), seq=<｜begin▁of▁sentence｜>A conversation between User and Assistant. The user asks a question, and the Assistant solves it.
The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., <think> reasoning process here </think>
<answer>answer here</answer>
Do not explain your reasoning inside the answer tags, provide only the final answer. When an example is provided, you should strictly follow the format of the output/answer in that example.
<｜User｜>Two strings are isomorphic if the characters in one string can be replaced to get the second string.

All occurrences of a character must be replaced with another character while preserving the order of characters.

No two characters may map to the same character, but a character may map to itself.

Return True if the following two strings are isomorphic, or False otherwise:
aitdkrkzbk rixvyzyonz
<｜Assistant｜><think>
Alright, I need to determine if the two given strings are isomorphic. The strings are:
aitdkrkzbk rixvyzyonz

First, I notice that each string seems to have a specific order of characters, and we're trying to see if they follow a similar pattern. Isomorphic strings, according to the description, mean that each character in one string can be replaced with another to get the other string, preserving the order, and no two characters map to the same one.

So, I should check each character in both strings to see if they follow this structure. If every corresponding character is consistently mapped to another unique character in the other string, with no duplicates, then they are isomorphic.

Comparing the two strings:
1. First few characters must be checked thoroughly to ensure the mapping holds consistently across the entire length.
</think>

<answer>True</answer><｜end▁of▁sentence｜>
step:2 - global_seqlen/min:53954.000 - global_seqlen/max:57020.000 - global_seqlen/minmax_diff:3066.000 - global_seqlen/balanced_min:55487.000 - global_seqlen/balanced_max:55487.000 - global_seqlen/mean:55487.000 - actor/kl_loss:0.001 - actor/kl_coef:0.001 - actor/entropy_loss:0.839 - actor/pg_loss:0.245 - actor/pg_clipfrac:0.000 - actor/ppo_kl:-0.000 - actor/grad_norm:0.365 - perf/mfu/actor:0.000 - perf/max_memory_allocated_gb:36.245 - perf/max_memory_reserved_gb:45.887 - perf/cpu_memory_used_gb:61.689 - actor/lr:0.000 - critic/score/mean:0.430 - critic/score/max:2.000 - critic/score/min:0.000 - critic/rewards/mean:0.430 - critic/rewards/max:2.000 - critic/rewards/min:0.000 - critic/advantages/mean:-0.134 - critic/advantages/max:2.475 - critic/advantages/min:-1.135 - critic/returns/mean:-0.134 - critic/returns/max:2.475 - critic/returns/min:-1.135 - response_length/mean:666.234 - response_length/max:829.000 - response_length/min:180.000 - response_length/clip_ratio:0.000 - prompt_length/mean:200.750 - prompt_length/max:205.000 - prompt_length/min:197.000 - prompt_length/clip_ratio:0.000 - timing_s/gen:23.489 - timing_s/old_log_prob:2.277 - timing_s/ref:2.392 - timing_s/adv:0.067 - timing_s/update_actor:12.429 - timing_s/step:40.660 - timing_per_token_ms/gen:0.275 - timing_per_token_ms/adv:0.001 - timing_per_token_ms/ref:0.022 - timing_per_token_ms/update_actor:0.112 - perf/total_num_tokens:110974.000 - perf/time_per_step:40.660 - perf/throughput:1364.673

Training Progress:   0%|          | 2/625 [01:24<7:14:00, 41.80s/it]

```