### PR TITLE
fix(visualization): Sort models in heatmap by overall performance

### DIFF
--- a/eval/visualize_results.py
+++ b/eval/visualize_results.py
@@ -385,7 +385,12 @@ def create_performance_heatmap(summaries: Dict[str, Dict[str, Any]], categories:
     for category, datasets in sorted(categories.items()):
         all_datasets.extend(sorted(datasets))
 
-    models = list(summaries.keys())
+    # Sort models by overall performance
+    overall_scores = {}
+    for model_name, summary in summaries.items():
+        scores = list(summary["dataset_best_scores"].values())
+        overall_scores[model_name] = np.mean(scores)
+    models = [item[0] for item in sorted(overall_scores.items(), key=lambda x: x[1], reverse=True)]
 
     # Create score matrix
     score_matrix = np.zeros((len(models), len(all_datasets)))


### PR DESCRIPTION
Seems to work fine:

![overall_performance](https://github.com/user-attachments/assets/f5bd54cb-cd48-4589-b810-31be29b6ee49)
![performance_heatmap](https://github.com/user-attachments/assets/048a3b3b-2918-4323-8b5e-6c6b77015ba3)
