### PR TITLE
fix boxnet scoring function

### DIFF
--- a/reasoning_gym/games/boxnet.py
+++ b/reasoning_gym/games/boxnet.py
@@ -57,6 +57,11 @@ def action_from_response(pg_dict_input, original_response_dict_list):
         for key, value in transformed_dict.items():
             current_pos = f"{key[0]}_{key[1]}"
 
+            # Check if current pos is not in the grid, i.e. the LLM hallucinated a non-existent position
+            if current_pos not in pg_dict_current:
+                # For now, we just skip these invalid moves, but it may be desirable to also penalise them somehow
+                continue
+
             # Check if this is a box-target matching move
             if (
                 value[0] in pg_dict_current[current_pos]
@@ -202,7 +207,8 @@ class BoxnetDataset(ProceduralDataset):
             try:
                 answer_dict = json.loads(answer)
             except:
-                return 0.01
+                return 0.00
+
             pg_dict_returned = action_from_response(entry["metadata"]["initial_state"], answer_dict)
 
             initial_boxes = 0

--- a/reasoning_gym/games/tower_of_hanoi.py
+++ b/reasoning_gym/games/tower_of_hanoi.py
@@ -343,9 +343,14 @@ class HanoiDataset(ProceduralDataset):
             if len(parts) != 9:
                 # print(f"Unexpected move format: '{move}'")
                 return False
-            disk = int(parts[2])
-            from_peg = int(parts[5])
-            to_peg = int(parts[8])
+
+            try:
+                disk = int(parts[2])
+                from_peg = int(parts[5])
+                to_peg = int(parts[8])
+            except ValueError:
+                # print(f"Invalid move format, or bad disk or peg number in move: '{move}'")
+                return False
 
             # Check if the disk to move is the top disk on the from_peg
             if not pegs_state[from_peg] or pegs_state[from_peg][-1] != disk:


### PR DESCRIPTION
avoids error and subsequent training crash if the response contains an invalid starting position

this also adds a new check to tower_of_hanoi to avoid an error print in cases where the response is formatted wrongly

closes #417 