### PR TITLE
fix decimal arithmetic curriculum to respect constraints

### DIFF
--- a/reasoning_gym/arithmetic/decimal_arithmetic.py
+++ b/reasoning_gym/arithmetic/decimal_arithmetic.py
@@ -237,7 +237,7 @@ class DecimalArithmeticCurriculum(BaseCurriculum):
         self._define_attributes(
             RangeAttributeDefinition(
                 name="decimal_places",
-                levels=[3, 5, 8, 10],
+                levels=[2, 4, 6, 8],
                 description="Number of decimal places of the numbers in problem",
                 lower_field_name="min_num_decimal_places",
                 upper_field_name="max_num_decimal_places",
@@ -247,7 +247,7 @@ class DecimalArithmeticCurriculum(BaseCurriculum):
                 name="precision",
                 field_name="precision",
                 description="Precision of the Decimal arithmetic operations",
-                levels=[5, 7, 10, 12],
+                levels=[6, 8, 10, 12],
             ),
             RangeAttributeDefinition(
                 name="num_terms",

--- a/tests/test_decimal_arithmetic.py
+++ b/tests/test_decimal_arithmetic.py
@@ -63,25 +63,25 @@ def test_decimal_arithmetic_curriculum():
     base_cfg: DecimalArithmeticConfig = curriculum.generate_configuration(base_value)
     assert base_cfg.seed == 42
     assert base_cfg.size == 200
-    assert base_cfg.precision == 5
-    assert base_cfg.min_num_decimal_places == 3 and base_cfg.max_num_decimal_places == 5
+    assert base_cfg.precision == 6
+    assert base_cfg.min_num_decimal_places == 2 and base_cfg.max_num_decimal_places == 4
 
     # Test incrementing attribute level
     curriculum.increment_attr_level("decimal_places")
     increased_cfg = curriculum.generate_configuration(base_value)
-    assert increased_cfg.min_num_decimal_places == 3 and increased_cfg.max_num_decimal_places == 8
+    assert increased_cfg.min_num_decimal_places == 2 and increased_cfg.max_num_decimal_places == 6
 
     # Test incrementing attribute level again
     curriculum.increment_attr_level("decimal_places")
     further_increased_cfg = curriculum.generate_configuration(base_value)
-    assert further_increased_cfg.min_num_decimal_places == 3 and further_increased_cfg.max_num_decimal_places == 10
+    assert further_increased_cfg.min_num_decimal_places == 2 and further_increased_cfg.max_num_decimal_places == 8
 
     # Test decrementing attribute level
     curriculum.decrement_attr_level("decimal_places")
     decreased_cfg = curriculum.generate_configuration(base_value)
-    assert decreased_cfg.min_num_decimal_places == 3 and decreased_cfg.max_num_decimal_places == 8
+    assert decreased_cfg.min_num_decimal_places == 2 and decreased_cfg.max_num_decimal_places == 6
 
     # Test decrementing attribute level to base level
     curriculum.decrement_attr_level("decimal_places")
     base_level_cfg = curriculum.generate_configuration(base_value)
-    assert base_level_cfg.min_num_decimal_places == 3 and base_level_cfg.max_num_decimal_places == 5
+    assert base_level_cfg.min_num_decimal_places == 2 and base_level_cfg.max_num_decimal_places == 4


### PR DESCRIPTION
with the previous values, some levels of the curriculum had constraints which were not compatible according to [this validation check](https://github.com/open-thought/reasoning-gym/blob/475904a74d4cf976d6891152e535993f7afd16bd/reasoning_gym/arithmetic/decimal_arithmetic.py#L28)

with the updated version, violations are still possible if one attribute's level is updated without the other, but this at least ensures that whenever all attributes are set at the same level, constraints are respected