### PR TITLE
Use raw URLs for images in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
     <!-- title -->
-    <h1 align="center"><img src="https://github.com/open-thought/reasoning-gym/blob/main/assets/icon.png" alt="Reasoning Gym Logo" style="vertical-align: bottom;" width="54px" height="40px"> Reasoning Gym</h1>
+    <h1 align="center"><img src="https://github.com/open-thought/reasoning-gym/raw/main/assets/icon.png" alt="Reasoning Gym Logo" style="vertical-align: bottom;" width="54px" height="40px"> Reasoning Gym</h1>
     <!-- teaser -->
     <p align="center">
-        <img src="https://github.com/open-thought/reasoning-gym/blob/main/assets/examples.png" width="800px">
+        <img src="https://github.com/open-thought/reasoning-gym/raw/main/assets/examples.png" width="800px">
     </p>
     <!-- badges -->
     <p align="center">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reasoning_gym"
-version = "0.1.19"
+version = "0.1.23"
 authors = [
   { name = "Open-Thought community", email = "andreas.koepf@xamla.com" },
 ]


### PR DESCRIPTION
On pypi images were not correctly rendered because the old img src urls in README.md pointed to files on github with UI.