### PR TITLE
Fix(reasoning_gym/games/countdown):  Resolve SymPy parsing conflict for 10+ input numbers

### DIFF
--- a/reasoning_gym/games/countdown.py
+++ b/reasoning_gym/games/countdown.py
@@ -178,7 +178,7 @@ class CountdownDataset(ProceduralDataset):
         for sym_name, num_str in replacements:
             expr_str = expr_str.replace(sym_name, num_str)
 
-        return expr, numbers, syms
+        return expr, numbers, syms, expr_str
 
     def _generate_expression(self, rng: Random) -> tuple[str, list[int], int]:
         """Generate a valid expression and its result

--- a/reasoning_gym/games/countdown.py
+++ b/reasoning_gym/games/countdown.py
@@ -127,7 +127,7 @@ class CountdownDataset(ProceduralDataset):
         numbers = [rng.randint(self.config.min_value, self.config.max_value) for _ in range(num_terms)]
 
         # Create symbols for building expression
-        syms = symbols(f"x:{num_terms}")
+        syms = symbols(f"x_{0}:{num_terms}")
 
         # Build random expression
         expr = syms[0]
@@ -161,6 +161,22 @@ class CountdownDataset(ProceduralDataset):
                 else:
                     # Fallback to addition for zero
                     expr = expr + syms[i]
+                    
+        # Safely replace symbols with numbers (to avoid name conflicts)
+        expr_str = str(expr)
+
+        # Create a list of replacements: [(symbol_name, number_string), ...]
+        replacements = []
+        for i, sym in enumerate(syms):
+            sym_name = str(sym)
+            replacements.append((sym_name, str(numbers[i])))
+
+        # Sort by symbol name length in descending order (replace longer names first)
+        replacements.sort(key=lambda x: len(x[0]), reverse=True)
+
+        # Perform the safe replacement
+        for sym_name, num_str in replacements:
+            expr_str = expr_str.replace(sym_name, num_str)
 
         return expr, numbers, syms
 
@@ -175,14 +191,13 @@ class CountdownDataset(ProceduralDataset):
         max_attempts = 100
         for attempt in range(max_attempts):
             try:
-                expr, numbers, syms = self._generate_candidate_expression(rng, num_terms)
+                expr, numbers, syms, expr_str = self._generate_candidate_expression(rng, num_terms)
 
                 # Substitute actual numbers to get target
                 subs = {sym: num for sym, num in zip(syms, numbers)}
                 target = int(expr.subs(subs))
 
                 # Convert to string expression
-                expr_str = str(expr)
                 for i, sym in enumerate(syms):
                     expr_str = expr_str.replace(str(sym), str(numbers[i]))
 

--- a/reasoning_gym/games/countdown.py
+++ b/reasoning_gym/games/countdown.py
@@ -161,7 +161,7 @@ class CountdownDataset(ProceduralDataset):
                 else:
                     # Fallback to addition for zero
                     expr = expr + syms[i]
-                    
+
         # Safely replace symbols with numbers (to avoid name conflicts)
         expr_str = str(expr)
 

--- a/tests/test_countdown.py
+++ b/tests/test_countdown.py
@@ -113,6 +113,12 @@ def test_edge_cases_2():
     item = {"metadata": {"numbers": [6, 34, 1, 11], "target": 17}}
     assert dataset.score_answer(answer=answer, entry=item) != 1.0
 
+def test_countdown_more_numbers():
+    """Test when min_numbers exceed 10"""
+    dataset = CountdownDataset(CountdownConfig(min_numbers=11, max_numbers=11, shuffle=False, size=5, seed=42))  # Set 11 engaged numbers for testing
+
+    for item in dataset:
+        assert item["metadata"]["target"] == int(eval(item["metadata"]["expression"]))
 
 def test_countdown_game_randomization():
     """Test number randomization configuration"""

--- a/tests/test_countdown.py
+++ b/tests/test_countdown.py
@@ -113,12 +113,16 @@ def test_edge_cases_2():
     item = {"metadata": {"numbers": [6, 34, 1, 11], "target": 17}}
     assert dataset.score_answer(answer=answer, entry=item) != 1.0
 
+
 def test_countdown_more_numbers():
     """Test when min_numbers exceed 10"""
-    dataset = CountdownDataset(CountdownConfig(min_numbers=11, max_numbers=11, shuffle=False, size=5, seed=42))  # Set 11 engaged numbers for testing
+    dataset = CountdownDataset(
+        CountdownConfig(min_numbers=11, max_numbers=11, shuffle=False, size=5, seed=42)
+    )  # Set 11 engaged numbers for testing
 
     for item in dataset:
         assert item["metadata"]["target"] == int(eval(item["metadata"]["expression"]))
+
 
 def test_countdown_game_randomization():
     """Test number randomization configuration"""


### PR DESCRIPTION
Hi!

Thanks for your work! I really appreciate your effort in building a unified benchmark. This PR addresses a bug in the `reasoning_gym/games/countdown` module where the SymPy symbol replacement logic fails when the number of input numbers (`num_terms`) is 10 or greater.

### 🐛 Problem

The current implementation for generating and validating the arithmetic expression breaks down when there are more than 9 unique symbols (representing the input numbers). This causes the expression string to contain incorrect, phantom numbers, leading to an `AssertionError` during the final answer validation.

The error occurs because the original symbol naming scheme creates ambiguity when the indices transition from single to double digits.

### 🐞 Root Cause

The original symbol generation used a format like `syms = symbols(f"x:{num_terms}")`, resulting in symbols like `x0, x1, ..., x9, x10, x11, ...`.

During the subsequent string replacement to substitute the symbol names (`x10`, `x11`, etc.) with the actual numbers, the string `"10"` within `"x10"` was mistakenly matched and replaced before the full `"x10"` symbol, causing a collision.

**Example Trace:**
In an example with 15 numbers:
```
q="Calculate 4109 using all of these numbers: 288, 258, 234, 214, 292, 221, 283, 249, 214, 251, 251, 216, 261, 289, 253.
```
Symbols `x10` through `x14` were incorrectly processed, leading to the unexpected presence of numbers like `-2510`, `-2511`, etc. (which are not in the available set) in the final expression string:
```
a="-2510 - 2511 + 2512 + 2513 - 2514 + 253*(214 + 251 - 251 + 258 - 234 - 249 + 288 - 261) + 283"
```
This expression is obviously incorrect. The symbol generation is corrected to explicitly include an underscore separator, ensuring that each symbol name is unique and unambiguous during string replacement, regardless of the number of terms.

### ✅ Fix
The line is updated from:
```python
# Old logic:
# syms = symbols(f"x:{num_terms}")
```
to
```python
# New logic:
syms = symbols(f"x_{0}:{num_terms}")
```
The following logic for `expr_str` generation has been updated accordingly to handle the new x_N format.

With this fix, the expression is generated correctly using only the valid input numbers:
```
a="-221 - 214 + 216 + 289 - 292 + 253*(214 + 251 - 251 + 258 - 234 - 249 + 288 - 261) + 283"
```
And the answer is 4109, which is correct.